### PR TITLE
feat(skills): add [PROGRESS] marker and TodoWrite step tracking to multi-step skills

### DIFF
--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -27,9 +27,34 @@ If the user says "continue" or "resume":
 Store:
 - `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
 
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 10 items, all `pending`:
+```
+Step 1/10: Load Config
+Step 2/10: Load Implementation Doc
+Step 3/10: Analyze Task Dependencies
+Step 4/10: Choose Execution Path
+Step 5/10: Pre-Implementation Check
+Step 6/10: Route Execution
+Step 7/10: Implementation Loop
+Step 8/10: Full Test Run
+Step 9/10: Summary
+Step 10/10: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/10 `completed`:
+```
+Step 1/10: Load Config [completed]
+Files read: .paadhai.json
+```
+
 ---
 
 ## STEP 2 — Load Implementation Doc
+
+[PROGRESS] Mark Step 2/10 `in_progress`: `Step 2/10: Load Implementation Doc [in_progress]`
 
 [SHELL] Get current branch:
 ```bash
@@ -50,9 +75,14 @@ Ask user:
 - Model preference? (fast / smart / auto)
 - Auto-commit after each step? (yes / no)
 
+[PROGRESS] Mark Step 2/10 `completed`: `Step 2/10: Load Implementation Doc [completed]`
+`Files read: docs/plans/issue-<n>/implementation.md, docs/plans/issue-<n>/plan.md`
+
 ---
 
 ## STEP 3 — Analyze Task Dependencies
+
+[PROGRESS] Mark Step 3/10 `in_progress`: `Step 3/10: Analyze Task Dependencies [in_progress]`
 
 Scan implementation steps for:
 - **Sequential patterns**: step B requires step A's output
@@ -60,9 +90,14 @@ Scan implementation steps for:
 
 If 3+ independent tasks with <20% dependencies → offer subagent-driven mode.
 
+[PROGRESS] Mark Step 3/10 `completed`: `Step 3/10: Analyze Task Dependencies [completed]`
+`Analysis complete`
+
 ---
 
 ## STEP 4 — Choose Execution Path
+
+[PROGRESS] Mark Step 4/10 `in_progress`: `Step 4/10: Choose Execution Path [in_progress]`
 
 - **Independent-heavy** → offer: subagent-driven OR sequential
 - **Sequential-heavy** → sequential only
@@ -70,9 +105,14 @@ If 3+ independent tasks with <20% dependencies → offer subagent-driven mode.
 
 Display the dependency analysis and let user choose.
 
+[PROGRESS] Mark Step 4/10 `completed`: `Step 4/10: Choose Execution Path [completed]`
+`Decision made`
+
 ---
 
 ## STEP 5 — Pre-Implementation Check
+
+[PROGRESS] Mark Step 5/10 `in_progress`: `Step 5/10: Pre-Implementation Check [in_progress]`
 
 [SHELL] Verify branch and working state:
 ```bash
@@ -83,16 +123,26 @@ git status
 - Must be on feature branch (not `{config.repo.develop_branch}` or `main`)
 - Working tree must be clean (or stash uncommitted work first)
 
+[PROGRESS] Mark Step 5/10 `completed`: `Step 5/10: Pre-Implementation Check [completed]`
+`Branch verified, working tree clean`
+
 ---
 
 ## STEP 6 — Route Execution
 
+[PROGRESS] Mark Step 6/10 `in_progress`: `Step 6/10: Route Execution [in_progress]`
+
 - **Subagent-driven** → hand off to `/paadhai:dev-parallel`. Pass the issue number as context.
 - **Sequential** → continue to Step 7
+
+[PROGRESS] Mark Step 6/10 `completed`: `Step 6/10: Route Execution [completed]`
+`Route determined`
 
 ---
 
 ## STEP 7 — Implementation Loop
+
+[PROGRESS] Mark Step 7/10 `in_progress`: `Step 7/10: Implementation Loop [in_progress]`
 
 For each `pending` step in the implementation doc:
 
@@ -159,9 +209,14 @@ Commit type guide:
 
 Subject: max 72 chars, imperative mood ("add X" not "added X").
 
+[PROGRESS] Mark Step 7/10 `completed`: `Step 7/10: Implementation Loop [completed]`
+`Files changed: <list from step>  Build: ✓  Lint: ✓`
+
 ---
 
 ## STEP 8 — Full Test Run
+
+[PROGRESS] Mark Step 8/10 `in_progress`: `Step 8/10: Full Test Run [in_progress]`
 
 [SHELL] After all steps complete:
 ```bash
@@ -172,9 +227,14 @@ Subject: max 72 chars, imperative mood ("add X" not "added X").
 
 Fix any failures before proceeding. Do not skip.
 
+[PROGRESS] Mark Step 8/10 `completed`: `Step 8/10: Full Test Run [completed]`
+`Build: ✓  Lint: ✓  Tests: <count> passing`
+
 ---
 
 ## STEP 9 — Summary
+
+[PROGRESS] Mark Step 9/10 `in_progress`: `Step 9/10: Summary [in_progress]`
 
 Display:
 ```
@@ -187,9 +247,14 @@ Lint    : ✓
 Tests   : <pass count> passing
 ```
 
+[PROGRESS] Mark Step 9/10 `completed`: `Step 9/10: Summary [completed]`
+`Output displayed`
+
 ---
 
 ## STEP 10 — Handoff
+
+[PROGRESS] Mark Step 10/10 `in_progress`: `Step 10/10: Handoff [in_progress]`
 
 ```
 Run /dev-pr to push the branch and open a pull request.
@@ -197,3 +262,6 @@ Run /dev-pr to push the branch and open a pull request.
 Branch  : <branch-name>
 Issue   : #<number>
 ```
+
+[PROGRESS] Mark Step 10/10 `completed`: `Step 10/10: Handoff [completed]`
+`Output displayed`

--- a/.claude/skills/dev-parallel/SKILL.md
+++ b/.claude/skills/dev-parallel/SKILL.md
@@ -19,9 +19,38 @@ Store:
 - `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
 - `{config.repo.owner}` / `{config.repo.name}`
 
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 14 items, all `pending`:
+```
+Step 1/14: Load Config
+Step 2/14: Load Implementation Doc
+Step 3/14: Group Independent Tasks
+Step 4/14: Generate Subagent Prompts
+Step 5/14: Dispatch Gate
+Step 6/14: Dispatch Subagents (after G-11)
+Step 7/14: Collect Results
+Step 8/14: Stage 1: Spec Compliance Review
+Step 9/14: Stage 2: Code Quality Review
+Step 10/14: Fix Loop
+Step 11/14: Update Implementation Doc
+Step 12/14: Full Test Run
+Step 13/14: Summary
+Step 14/14: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/14 `completed`:
+```
+Step 1/14: Load Config [completed]
+Files read: .paadhai.json
+```
+
 ---
 
 ## STEP 2 — Load Implementation Doc
+
+[PROGRESS] Mark Step 2/14 `in_progress`: `Step 2/14: Load Implementation Doc [in_progress]`
 
 [SHELL] Get current branch:
 ```bash
@@ -40,9 +69,14 @@ Steps     : <total count>
 Doc path  : docs/plans/issue-<n>/implementation.md
 ```
 
+[PROGRESS] Mark Step 2/14 `completed`: `Step 2/14: Load Implementation Doc [completed]`
+`Files read: docs/plans/issue-<n>/implementation.md, docs/plans/issue-<n>/plan.md`
+
 ---
 
 ## STEP 3 — Group Independent Tasks
+
+[PROGRESS] Mark Step 3/14 `in_progress`: `Step 3/14: Group Independent Tasks [in_progress]`
 
 Scan implementation steps and build a dependency graph:
 - **Sequential**: step B requires step A's output (shared file, import, or state)
@@ -64,9 +98,14 @@ Group | Steps       | Files Touched          | Dependencies
 If no independent groups found (all sequential) → stop:
 > All tasks are sequential. Use `/paadhai:dev-implement` in sequential mode instead.
 
+[PROGRESS] Mark Step 3/14 `completed`: `Step 3/14: Group Independent Tasks [completed]`
+`Task groups identified`
+
 ---
 
 ## STEP 4 — Generate Subagent Prompts
+
+[PROGRESS] Mark Step 4/14 `in_progress`: `Step 4/14: Generate Subagent Prompts [in_progress]`
 
 For each independent task group, build a prompt containing:
 
@@ -88,17 +127,27 @@ For each independent task group, build a prompt containing:
 
 Display all generated prompts to user for review.
 
+[PROGRESS] Mark Step 4/14 `completed`: `Step 4/14: Generate Subagent Prompts [completed]`
+`Prompts generated`
+
 ---
 
 ## STEP 5 — Dispatch Gate
+
+[PROGRESS] Mark Step 5/14 `in_progress`: `Step 5/14: Dispatch Gate [in_progress]`
 
 **G-11: "Dispatch <N> subagents for parallel implementation? (yes/no)"**
 
 Wait for explicit "yes". Do not proceed without it.
 
+[PROGRESS] Mark Step 5/14 `completed`: `Step 5/14: Dispatch Gate [completed]`
+`Gate passed`
+
 ---
 
 ## STEP 6 — Dispatch Subagents (after G-11)
+
+[PROGRESS] Mark Step 6/14 `in_progress`: `Step 6/14: Dispatch Subagents (after G-11) [in_progress]`
 
 [PARALLEL] Dispatch one `[DELEGATE][FAST-MODEL]` per independent task group.
 
@@ -117,9 +166,14 @@ Each subagent:
 
 Sequential groups (those depending on earlier groups) are dispatched only after their dependencies complete.
 
+[PROGRESS] Mark Step 6/14 `completed`: `Step 6/14: Dispatch Subagents (after G-11) [completed]`
+`Subagents dispatched`
+
 ---
 
 ## STEP 7 — Collect Results
+
+[PROGRESS] Mark Step 7/14 `in_progress`: `Step 7/14: Collect Results [in_progress]`
 
 Wait for all subagents to complete.
 
@@ -141,9 +195,14 @@ If any group failed:
 - If skip → mark those steps as `pending` in implementation.md
 - If abort → stop
 
+[PROGRESS] Mark Step 7/14 `completed`: `Step 7/14: Collect Results [completed]`
+`Results collected`
+
 ---
 
 ## STEP 8 — Stage 1: Spec Compliance Review
+
+[PROGRESS] Mark Step 8/14 `in_progress`: `Step 8/14: Stage 1: Spec Compliance Review [in_progress]`
 
 [DELEGATE][SMART-MODEL] Review ALL changes against implementation.md:
 
@@ -156,9 +215,14 @@ Check:
 
 Report: **PASS** / **FAIL** with specific gaps listed.
 
+[PROGRESS] Mark Step 8/14 `completed`: `Step 8/14: Stage 1: Spec Compliance Review [completed]`
+`Spec review: PASS`
+
 ---
 
 ## STEP 9 — Stage 2: Code Quality Review
+
+[PROGRESS] Mark Step 9/14 `in_progress`: `Step 9/14: Stage 2: Code Quality Review [in_progress]`
 
 [DELEGATE][SMART-MODEL] Review ALL changes for:
 
@@ -172,9 +236,14 @@ Check:
 
 Report: **PASS** / **FAIL** with specific issues listed.
 
+[PROGRESS] Mark Step 9/14 `completed`: `Step 9/14: Stage 2: Code Quality Review [completed]`
+`Code review: PASS`
+
 ---
 
 ## STEP 10 — Fix Loop
+
+[PROGRESS] Mark Step 10/14 `in_progress`: `Step 10/14: Fix Loop [in_progress]`
 
 If either review reports **FAIL**:
 1. Display all findings
@@ -189,17 +258,27 @@ If either review reports **FAIL**:
 4. Re-run only the failed review stage (Stage 1 or Stage 2)
 5. Repeat until both stages report **PASS**
 
+[PROGRESS] Mark Step 10/14 `completed`: `Step 10/14: Fix Loop [completed]`
+`Fixes applied`
+
 ---
 
 ## STEP 11 — Update Implementation Doc
+
+[PROGRESS] Mark Step 11/14 `in_progress`: `Step 11/14: Update Implementation Doc [in_progress]`
 
 [READ] `docs/plans/issue-<n>/implementation.md`
 
 [WRITE] Mark all completed steps as `done`. Add deviation notes if any step differed from the original plan.
 
+[PROGRESS] Mark Step 11/14 `completed`: `Step 11/14: Update Implementation Doc [completed]`
+`Files changed: docs/plans/issue-<n>/implementation.md`
+
 ---
 
 ## STEP 12 — Full Test Run
+
+[PROGRESS] Mark Step 12/14 `in_progress`: `Step 12/14: Full Test Run [in_progress]`
 
 [SHELL] Run all checks:
 ```bash
@@ -210,9 +289,14 @@ If either review reports **FAIL**:
 
 If any fail → fix failures before proceeding. Do not skip.
 
+[PROGRESS] Mark Step 12/14 `completed`: `Step 12/14: Full Test Run [completed]`
+`Build: ✓  Lint: ✓  Tests: <count> passing`
+
 ---
 
 ## STEP 13 — Summary
+
+[PROGRESS] Mark Step 13/14 `in_progress`: `Step 13/14: Summary [in_progress]`
 
 Display:
 ```
@@ -228,9 +312,14 @@ Spec Review  : PASS
 Code Review  : PASS
 ```
 
+[PROGRESS] Mark Step 13/14 `completed`: `Step 13/14: Summary [completed]`
+`Output displayed`
+
 ---
 
 ## STEP 14 — Handoff
+
+[PROGRESS] Mark Step 14/14 `in_progress`: `Step 14/14: Handoff [in_progress]`
 
 ```
 Run /dev-pr to push the branch and open a pull request.
@@ -238,3 +327,6 @@ Run /dev-pr to push the branch and open a pull request.
 Branch  : <branch-name>
 Issue   : #<number>
 ```
+
+[PROGRESS] Mark Step 14/14 `completed`: `Step 14/14: Handoff [completed]`
+`Output displayed`

--- a/.claude/skills/dev-plan/SKILL.md
+++ b/.claude/skills/dev-plan/SKILL.md
@@ -22,9 +22,41 @@ Store config values:
 - `{config.repo.develop_branch}`
 - `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
 
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 17 items, all `pending`:
+```
+Step 1/17: Load Config
+Step 2/17: Identify Issue
+Step 3/17: Read Relevant Code
+Step 4/17: Scope Validation
+Step 5/17: Brainstorming Questions
+Step 6/17: Design Review
+Step 7/17: Security Threat Assessment
+Step 8/17: Version Validation
+Step 9/17: Generate Plan
+Step 10/17: Present Plan
+Step 11/17: Confirmation Loop
+Step 12/17: Save Plan
+Step 13/17: Generate Implementation Doc
+Step 14/17: Review Implementation Doc
+Step 15/17: User Confirms Implementation Doc
+Step 16/17: Commit
+Step 17/17: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/17 `completed`:
+```
+Step 1/17: Load Config [completed]
+Files read: .paadhai.json
+```
+
 ---
 
 ## STEP 2 — Identify Issue
+
+[PROGRESS] Mark Step 2/17 `in_progress`: `Step 2/17: Identify Issue [in_progress]`
 
 [SHELL] Get current branch:
 ```bash
@@ -46,15 +78,25 @@ Milestone : <milestone>
 Labels    : <labels>
 ```
 
+[PROGRESS] Mark Step 2/17 `completed`: `Step 2/17: Identify Issue [completed]`
+`Issue details fetched`
+
 ---
 
 ## STEP 3 — Read Relevant Code
 
+[PROGRESS] Mark Step 3/17 `in_progress`: `Step 3/17: Read Relevant Code [in_progress]`
+
 [DELEGATE][FAST-MODEL] Read existing source files relevant to the issue (based on labels and title). Read at minimum 3–5 files. Do not skip — makes questions and plan accurate.
+
+[PROGRESS] Mark Step 3/17 `completed`: `Step 3/17: Read Relevant Code [completed]`
+`Files read: <list of files read>`
 
 ---
 
 ## STEP 4 — Scope Validation
+
+[PROGRESS] Mark Step 4/17 `in_progress`: `Step 4/17: Scope Validation [in_progress]`
 
 Check:
 - **Clarity**: Can you describe the issue in one sentence?
@@ -63,9 +105,14 @@ Check:
 
 If unclear on any point → ask user before proceeding.
 
+[PROGRESS] Mark Step 4/17 `completed`: `Step 4/17: Scope Validation [completed]`
+`Scope validated`
+
 ---
 
 ## STEP 5 — Brainstorming Questions
+
+[PROGRESS] Mark Step 5/17 `in_progress`: `Step 5/17: Brainstorming Questions [in_progress]`
 
 Ask 5–7 targeted questions one at a time. Tailor to issue labels:
 - `api` → endpoint design, auth, versioning
@@ -79,9 +126,14 @@ Always ask:
 - Anything specific about the existing codebase I should know?
 - Does this align with existing patterns in the codebase?
 
+[PROGRESS] Mark Step 5/17 `completed`: `Step 5/17: Brainstorming Questions [completed]`
+`Questions asked`
+
 ---
 
 ## STEP 6 — Design Review
+
+[PROGRESS] Mark Step 6/17 `in_progress`: `Step 6/17: Design Review [in_progress]`
 
 [READ] 2–3 similar implementations in the codebase. Check:
 - Pattern alignment
@@ -103,9 +155,14 @@ Ask user: "This issue involves an architectural decision. Generate an ADR? (yes/
 - **yes** → after plan is saved (Step 12), invoke `/paadhai:dev-adr` with the decision context
 - **no** → note "ADR: declined" in the plan
 
+[PROGRESS] Mark Step 6/17 `completed`: `Step 6/17: Design Review [completed]`
+`Design review complete`
+
 ---
 
 ## STEP 7 — Security Threat Assessment
+
+[PROGRESS] Mark Step 7/17 `in_progress`: `Step 7/17: Security Threat Assessment [in_progress]`
 
 [DELEGATE][SMART-MODEL] Perform a threat model based on issue labels and design findings:
 
@@ -141,9 +198,14 @@ Ask user: "This issue involves an architectural decision. Generate an ADR? (yes/
 If no security-relevant attack surfaces are identified → output:
 > No security-relevant attack surfaces identified for this issue.
 
+[PROGRESS] Mark Step 7/17 `completed`: `Step 7/17: Security Threat Assessment [completed]`
+`Security assessment complete`
+
 ---
 
 ## STEP 8 — Version Validation
+
+[PROGRESS] Mark Step 8/17 `in_progress`: `Step 8/17: Version Validation [in_progress]`
 
 [DELEGATE][FAST-MODEL][SEARCH] Check current stable versions of core packages used in this issue. Verify:
 - Breaking changes since current version
@@ -152,9 +214,14 @@ If no security-relevant attack surfaces are identified → output:
 
 Skip for well-known stable APIs (e.g., standard library functions).
 
+[PROGRESS] Mark Step 8/17 `completed`: `Step 8/17: Version Validation [completed]`
+`Version validation complete`
+
 ---
 
 ## STEP 9 — Generate Plan
+
+[PROGRESS] Mark Step 9/17 `in_progress`: `Step 9/17: Generate Plan [in_progress]`
 
 Create a structured plan:
 
@@ -199,9 +266,14 @@ Create a structured plan:
 - ALL build/lint/test commands use `{config.stack.*}` — not `npm run X`
 - ALL branch references use `{config.repo.develop_branch}` — not `develop`
 
+[PROGRESS] Mark Step 9/17 `completed`: `Step 9/17: Generate Plan [completed]`
+`Plan generated`
+
 ---
 
 ## STEP 10 — Present Plan
+
+[PROGRESS] Mark Step 10/17 `in_progress`: `Step 10/17: Present Plan [in_progress]`
 
 Show the full plan.
 
@@ -209,17 +281,27 @@ Show the full plan.
 
 Wait for explicit approval.
 
+[PROGRESS] Mark Step 10/17 `completed`: `Step 10/17: Present Plan [completed]`
+`Plan presented`
+
 ---
 
 ## STEP 11 — Confirmation Loop
+
+[PROGRESS] Mark Step 11/17 `in_progress`: `Step 11/17: Confirmation Loop [in_progress]`
 
 - **Approved** → proceed to Step 12
 - **Changes requested** → update plan → re-present (repeat Step 10)
 - **Question** → answer → update if needed → re-present
 
+[PROGRESS] Mark Step 11/17 `completed`: `Step 11/17: Confirmation Loop [completed]`
+`Plan approved`
+
 ---
 
 ## STEP 12 — Save Plan
+
+[PROGRESS] Mark Step 12/17 `in_progress`: `Step 12/17: Save Plan [in_progress]`
 
 [WRITE] Save to `docs/plans/issue-<n>/plan.md`:
 
@@ -238,9 +320,14 @@ Followed by full plan content.
 
 If Step 6b ADR was approved → invoke `/paadhai:dev-adr` now with the architectural decision context.
 
+[PROGRESS] Mark Step 12/17 `completed`: `Step 12/17: Save Plan [completed]`
+`Files changed: docs/plans/issue-<n>/plan.md`
+
 ---
 
 ## STEP 13 — Generate Implementation Doc
+
+[PROGRESS] Mark Step 13/17 `in_progress`: `Step 13/17: Generate Implementation Doc [in_progress]`
 
 [WRITE] Create `docs/plans/issue-<n>/implementation.md`:
 
@@ -255,9 +342,14 @@ Include:
 
 Must reflect version validation findings from Step 8.
 
+[PROGRESS] Mark Step 13/17 `completed`: `Step 13/17: Generate Implementation Doc [completed]`
+`Files changed: docs/plans/issue-<n>/implementation.md`
+
 ---
 
 ## STEP 14 — Review Implementation Doc
+
+[PROGRESS] Mark Step 14/17 `in_progress`: `Step 14/17: Review Implementation Doc [in_progress]`
 
 [READ] `implementation-reviewer-prompt.md` — load review criteria.
 
@@ -270,9 +362,14 @@ Must reflect version validation findings from Step 8.
 
 **PASS/FAIL only.** Fix and retry until PASS.
 
+[PROGRESS] Mark Step 14/17 `completed`: `Step 14/17: Review Implementation Doc [completed]`
+`Review: PASS`
+
 ---
 
 ## STEP 15 — User Confirms Implementation Doc
+
+[PROGRESS] Mark Step 15/17 `in_progress`: `Step 15/17: User Confirms Implementation Doc [in_progress]`
 
 Present the implementation doc.
 
@@ -280,9 +377,14 @@ Present the implementation doc.
 
 Wait for explicit confirmation.
 
+[PROGRESS] Mark Step 15/17 `completed`: `Step 15/17: User Confirms Implementation Doc [completed]`
+`Implementation doc approved`
+
 ---
 
 ## STEP 16 — Commit
+
+[PROGRESS] Mark Step 16/17 `in_progress`: `Step 16/17: Commit [in_progress]`
 
 [SHELL] Commit plan + implementation doc:
 ```bash
@@ -294,9 +396,14 @@ git commit -m "docs(plan): add plan and implementation doc for issue #<n>
 Refs #<n>"
 ```
 
+[PROGRESS] Mark Step 16/17 `completed`: `Step 16/17: Commit [completed]`
+`Committed: docs/plans/issue-<n>/`
+
 ---
 
 ## STEP 17 — Handoff
+
+[PROGRESS] Mark Step 17/17 `in_progress`: `Step 17/17: Handoff [in_progress]`
 
 ```
 Planning complete. Next step: run /dev-test to create the test plan and stubs.
@@ -307,3 +414,6 @@ Impl doc    : docs/plans/issue-<n>/implementation.md
 Steps       : <count>
 Model tip   : Fast model recommended — doc is fully detailed.
 ```
+
+[PROGRESS] Mark Step 17/17 `completed`: `Step 17/17: Handoff [completed]`
+`Output displayed`

--- a/.claude/skills/dev-release/SKILL.md
+++ b/.claude/skills/dev-release/SKILL.md
@@ -21,9 +21,38 @@ Store:
 - `{config.branches.release}`
 - `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
 
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 14 items, all `pending`:
+```
+Step 1/14: Load Config
+Step 2/14: Verify Milestone Completion
+Step 3/14: Ask Version
+Step 4/14: Prepare Release Branch
+Step 5/14: Run Full Test Suite
+Step 6/14: Generate Changelog
+Step 7/14: Push + Create Release PR
+Step 8/14: Display Release PR URL
+Step 9/14: Final Confirmation
+Step 10/14: Execute Release (after G-10)
+Step 11/14: Close Milestone
+Step 12/14: Display Release URL
+Step 13/14: Post-Release Health Check
+Step 14/14: Next Milestone
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/14 `completed`:
+```
+Step 1/14: Load Config [completed]
+Files read: .paadhai.json
+```
+
 ---
 
 ## STEP 2 — Verify Milestone Completion
+
+[PROGRESS] Mark Step 2/14 `in_progress`: `Step 2/14: Verify Milestone Completion [in_progress]`
 
 [SHELL] Check open issues in the current milestone:
 ```bash
@@ -40,9 +69,14 @@ Open issues:
 
 If all closed → proceed.
 
+[PROGRESS] Mark Step 2/14 `completed`: `Step 2/14: Verify Milestone Completion [completed]`
+`Milestone verified: all issues closed`
+
 ---
 
 ## STEP 3 — Ask Version
+
+[PROGRESS] Mark Step 3/14 `in_progress`: `Step 3/14: Ask Version [in_progress]`
 
 Ask user:
 > "What version number for this release? (e.g., v0.1.0)"
@@ -52,9 +86,14 @@ Validate format: must match `v\d+\.\d+\.\d+` or similar semantic version.
 Ask user:
 > "What is the milestone title for this release? (e.g., v0.1 — Core)"
 
+[PROGRESS] Mark Step 3/14 `completed`: `Step 3/14: Ask Version [completed]`
+`Version confirmed`
+
 ---
 
 ## STEP 4 — Prepare Release Branch
+
+[PROGRESS] Mark Step 4/14 `in_progress`: `Step 4/14: Prepare Release Branch [in_progress]`
 
 [SHELL] Switch to develop and pull:
 ```bash
@@ -68,9 +107,14 @@ git checkout -b {config.branches.release}<version>
 git push -u origin {config.branches.release}<version>
 ```
 
+[PROGRESS] Mark Step 4/14 `completed`: `Step 4/14: Prepare Release Branch [completed]`
+`Release branch created and pushed`
+
 ---
 
 ## STEP 5 — Run Full Test Suite
+
+[PROGRESS] Mark Step 5/14 `in_progress`: `Step 5/14: Run Full Test Suite [in_progress]`
 
 [DELEGATE][FAST-MODEL] Run all checks:
 ```bash
@@ -84,9 +128,14 @@ If any fail → stop:
 
 If all pass → proceed.
 
+[PROGRESS] Mark Step 5/14 `completed`: `Step 5/14: Run Full Test Suite [completed]`
+`Build: ✓  Lint: ✓  Tests: <count> passing`
+
 ---
 
 ## STEP 6 — Generate Changelog
+
+[PROGRESS] Mark Step 6/14 `in_progress`: `Step 6/14: Generate Changelog [in_progress]`
 
 [SHELL] Get commits since last tag:
 ```bash
@@ -136,9 +185,14 @@ git commit -m "docs(changelog): add <version> changelog
 Refs release <version>"
 ```
 
+[PROGRESS] Mark Step 6/14 `completed`: `Step 6/14: Generate Changelog [completed]`
+`Files changed: CHANGELOG.md`
+
 ---
 
 ## STEP 7 — Push + Create Release PR
+
+[PROGRESS] Mark Step 7/14 `in_progress`: `Step 7/14: Push + Create Release PR [in_progress]`
 
 [SHELL] Create PR from release branch to main:
 ```bash
@@ -156,9 +210,14 @@ gh pr create \
 - [ ] Version bumped (if applicable)"
 ```
 
+[PROGRESS] Mark Step 7/14 `completed`: `Step 7/14: Push + Create Release PR [completed]`
+`PR created`
+
 ---
 
 ## STEP 8 — Display Release PR URL
+
+[PROGRESS] Mark Step 8/14 `in_progress`: `Step 8/14: Display Release PR URL [in_progress]`
 
 ```
 ✓ Release PR created: <pr-url>
@@ -168,17 +227,27 @@ Base branch : {config.repo.main_branch}
 From        : {config.branches.release}<version>
 ```
 
+[PROGRESS] Mark Step 8/14 `completed`: `Step 8/14: Display Release PR URL [completed]`
+`Output displayed`
+
 ---
 
 ## STEP 9 — Final Confirmation
+
+[PROGRESS] Mark Step 9/14 `in_progress`: `Step 9/14: Final Confirmation [in_progress]`
 
 **G-10: "Confirm: Merge release PR and publish release? (yes/no)"**
 
 Wait for explicit "yes". Do not proceed without it.
 
+[PROGRESS] Mark Step 9/14 `completed`: `Step 9/14: Final Confirmation [completed]`
+`Gate passed`
+
 ---
 
 ## STEP 10 — Execute Release (after G-10)
+
+[PROGRESS] Mark Step 10/14 `in_progress`: `Step 10/14: Execute Release (after G-10) [in_progress]`
 
 All at once — no intermediate confirmations.
 
@@ -210,9 +279,14 @@ gh release create <version> \
   --notes "<changelog-body-from-step-6>"
 ```
 
+[PROGRESS] Mark Step 10/14 `completed`: `Step 10/14: Execute Release (after G-10) [completed]`
+`Release merged, tagged, back-merged`
+
 ---
 
 ## STEP 11 — Close Milestone
+
+[PROGRESS] Mark Step 11/14 `in_progress`: `Step 11/14: Close Milestone [in_progress]`
 
 [SHELL] Close the milestone for this release:
 ```bash
@@ -225,9 +299,14 @@ gh api "repos/{config.repo.owner}/{config.repo.name}/milestones/$MILESTONE_NUMBE
 If milestone not found or already closed → warn and continue:
 > Milestone "<milestone-title>" not found or already closed. Skipping.
 
+[PROGRESS] Mark Step 11/14 `completed`: `Step 11/14: Close Milestone [completed]`
+`Milestone closed`
+
 ---
 
 ## STEP 12 — Display Release URL
+
+[PROGRESS] Mark Step 12/14 `in_progress`: `Step 12/14: Display Release URL [in_progress]`
 
 ```
 ✓ Release published: <release-url>
@@ -239,9 +318,14 @@ Notes    : from CHANGELOG.md
 Milestone: <milestone-title> closed
 ```
 
+[PROGRESS] Mark Step 12/14 `completed`: `Step 12/14: Display Release URL [completed]`
+`Output displayed`
+
 ---
 
 ## STEP 13 — Post-Release Health Check
+
+[PROGRESS] Mark Step 13/14 `in_progress`: `Step 13/14: Post-Release Health Check [in_progress]`
 
 [SHELL] Check CI status on main:
 ```bash
@@ -267,9 +351,14 @@ Signal       : <NONE / WARNING>
 If CI is failing or 3+ new issues filed in the last hour:
 > WARNING: Post-release signals suggest a problem. Consider running /dev-rollback if issues are critical.
 
+[PROGRESS] Mark Step 13/14 `completed`: `Step 13/14: Post-Release Health Check [completed]`
+`Health check complete`
+
 ---
 
 ## STEP 14 — Next Milestone
+
+[PROGRESS] Mark Step 14/14 `in_progress`: `Step 14/14: Next Milestone [in_progress]`
 
 [SHELL] Show open issues for next milestone:
 ```bash
@@ -283,3 +372,6 @@ Release <version> is live.
 Next milestone: <next-milestone-title> (<n> open issues)
 To start: run /dev-start #<next-issue-number>
 ```
+
+[PROGRESS] Mark Step 14/14 `completed`: `Step 14/14: Next Milestone [completed]`
+`Output displayed`

--- a/.claude/skills/project-plan/SKILL.md
+++ b/.claude/skills/project-plan/SKILL.md
@@ -21,9 +21,34 @@ Derive SRS output path from config:
 - If `project_version` exists → `{srs_path}` = `docs/srs-v{project_version}.md`
 - If `project_version` absent → `{srs_path}` = `docs/srs.md`
 
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 10 items, all `pending`:
+```
+Step 1/10: Load Config
+Step 2/10: Read Existing Context
+Step 3/10: Product Description
+Step 4/10: Clarifying Questions
+Step 5/10: Research
+Step 6/10: Generate SRS
+Step 7/10: Present SRS
+Step 8/10: Revision Loop
+Step 9/10: Save
+Step 10/10: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/10 `completed`:
+```
+Step 1/10: Load Config [completed]
+Files read: .paadhai.json
+```
+
 ---
 
 ## STEP 2 — Read Existing Context
+
+[PROGRESS] Mark Step 2/10 `in_progress`: `Step 2/10: Read Existing Context [in_progress]`
 
 [READ] any existing docs in `docs/` or source files if project has code already. Understand current state before asking questions.
 
@@ -33,17 +58,27 @@ If `project_version` is set in config:
   > Loaded prior SRS (`{prior_srs_filename}`) as reference for delta planning.
 - Use the prior SRS to understand existing features, so the user can focus on what's new or changed in this version.
 
+[PROGRESS] Mark Step 2/10 `completed`: `Step 2/10: Read Existing Context [completed]`
+`Files read: <existing docs found>`
+
 ---
 
 ## STEP 3 — Product Description
+
+[PROGRESS] Mark Step 3/10 `in_progress`: `Step 3/10: Product Description [in_progress]`
 
 Ask the user to describe the product or feature set in free-form. Single input round.
 
 > "Describe what you want to build. Include the problem it solves, who uses it, and any key features you have in mind."
 
+[PROGRESS] Mark Step 3/10 `completed`: `Step 3/10: Product Description [completed]`
+`Description received`
+
 ---
 
 ## STEP 4 — Clarifying Questions
+
+[PROGRESS] Mark Step 4/10 `in_progress`: `Step 4/10: Clarifying Questions [in_progress]`
 
 Ask all questions at once — single input round:
 
@@ -56,18 +91,28 @@ Ask all questions at once — single input round:
 7. Any compliance, security, or performance requirements?
 8. Are there existing systems this must integrate with?
 
+[PROGRESS] Mark Step 4/10 `completed`: `Step 4/10: Clarifying Questions [completed]`
+`Answers received`
+
 ---
 
 ## STEP 5 — Research
+
+[PROGRESS] Mark Step 5/10 `in_progress`: `Step 5/10: Research [in_progress]`
 
 [DELEGATE][FAST-MODEL][SEARCH] Validate tech stack choices from Step 4:
 - Check current stable versions of proposed frameworks/libraries
 - Verify compatibility between components
 - Check for known issues with the proposed combination
 
+[PROGRESS] Mark Step 5/10 `completed`: `Step 5/10: Research [completed]`
+`Research complete`
+
 ---
 
 ## STEP 6 — Generate SRS
+
+[PROGRESS] Mark Step 6/10 `in_progress`: `Step 6/10: Generate SRS [in_progress]`
 
 Use `templates/srs.md` as the base template. Fill in all sections:
 
@@ -85,9 +130,14 @@ Use `templates/srs.md` as the base template. Fill in all sections:
 - Acceptance criteria must be specific and testable
 - No vague requirements ("should be fast" → "response time < 200ms under 100 concurrent users")
 
+[PROGRESS] Mark Step 6/10 `completed`: `Step 6/10: Generate SRS [completed]`
+`SRS generated`
+
 ---
 
 ## STEP 7 — Present SRS
+
+[PROGRESS] Mark Step 7/10 `in_progress`: `Step 7/10: Present SRS [in_progress]`
 
 Show the full SRS document.
 
@@ -95,16 +145,26 @@ Show the full SRS document.
 
 Wait for explicit approval.
 
+[PROGRESS] Mark Step 7/10 `completed`: `Step 7/10: Present SRS [completed]`
+`SRS presented`
+
 ---
 
 ## STEP 8 — Revision Loop
 
+[PROGRESS] Mark Step 8/10 `in_progress`: `Step 8/10: Revision Loop [in_progress]`
+
 - **Approved** → proceed to Step 9
 - **Changes requested** → apply changes → re-present full SRS → repeat G-02
+
+[PROGRESS] Mark Step 8/10 `completed`: `Step 8/10: Revision Loop [completed]`
+`SRS approved`
 
 ---
 
 ## STEP 9 — Save
+
+[PROGRESS] Mark Step 9/10 `in_progress`: `Step 9/10: Save [in_progress]`
 
 [WRITE] Save SRS to `{srs_path}`.
 
@@ -118,11 +178,19 @@ Refs: product description confirmed by user."
 
 > If no `project_version`, commit message omits the version suffix: `"docs(srs): add confirmed SRS"`.
 
+[PROGRESS] Mark Step 9/10 `completed`: `Step 9/10: Save [completed]`
+`Files changed: {srs_path}`
+
 ---
 
 ## STEP 10 — Handoff
+
+[PROGRESS] Mark Step 10/10 `in_progress`: `Step 10/10: Handoff [in_progress]`
 
 ```
 SRS saved to {srs_path}.
 Next step: run /release-plan to create your GitHub project milestones and issues.
 ```
+
+[PROGRESS] Mark Step 10/10 `completed`: `Step 10/10: Handoff [completed]`
+`Output displayed`

--- a/.claude/skills/release-plan/SKILL.md
+++ b/.claude/skills/release-plan/SKILL.md
@@ -30,9 +30,32 @@ Store:
 - `{config.github.project_id}` / `{config.github.status_field_id}` / `{config.github.statuses.todo}`
 - `{config.project_version}` (if present)
 
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 8 items, all `pending`:
+```
+Step 1/8: Load Config + SRS
+Step 2/8: Analyze Requirements
+Step 3/8: Create Issues
+Step 4/8: Present Release Plan
+Step 5/8: Revision Loop
+Step 6/8: Create on GitHub (after G-03)
+Step 7/8: Summary
+Step 8/8: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/8 `completed`:
+```
+Step 1/8: Load Config + SRS [completed]
+Files read: .paadhai.json, docs/srs-v{project_version}.md
+```
+
 ---
 
 ## STEP 2 — Analyze Requirements
+
+[PROGRESS] Mark Step 2/8 `in_progress`: `Step 2/8: Analyze Requirements [in_progress]`
 
 Read all functional requirements (FR-*) in the SRS. Group them into milestones by logical delivery increments.
 
@@ -45,9 +68,14 @@ Rules:
 - Each milestone should take roughly equal effort
 - Dependencies between milestones should be explicit
 
+[PROGRESS] Mark Step 2/8 `completed`: `Step 2/8: Analyze Requirements [completed]`
+`Requirements analyzed`
+
 ---
 
 ## STEP 3 — Create Issues
+
+[PROGRESS] Mark Step 3/8 `in_progress`: `Step 3/8: Create Issues [in_progress]`
 
 For each milestone, break it into atomic, independently-deliverable issues.
 
@@ -82,9 +110,14 @@ Issue rules:
 - Must be assigned to a milestone
 - Use appropriate labels: `feature`, `bug`, `api`, `db`, `test`, `auth`, `infra`, `docs`
 
+[PROGRESS] Mark Step 3/8 `completed`: `Step 3/8: Create Issues [completed]`
+`Issue list created`
+
 ---
 
 ## STEP 4 — Present Release Plan
+
+[PROGRESS] Mark Step 4/8 `in_progress`: `Step 4/8: Present Release Plan [in_progress]`
 
 Show the complete release plan:
 
@@ -108,17 +141,27 @@ Total: <milestone count> milestones, <issue count> issues
 
 Wait for explicit approval.
 
+[PROGRESS] Mark Step 4/8 `completed`: `Step 4/8: Present Release Plan [completed]`
+`Plan presented`
+
 ---
 
 ## STEP 5 — Revision Loop
+
+[PROGRESS] Mark Step 5/8 `in_progress`: `Step 5/8: Revision Loop [in_progress]`
 
 - **Approved** → proceed to Step 6
 - **Changes requested** → apply → re-present full plan → repeat G-03
 - **Question** → answer → update if needed → re-present
 
+[PROGRESS] Mark Step 5/8 `completed`: `Step 5/8: Revision Loop [completed]`
+`Plan approved`
+
 ---
 
 ## STEP 6 — Create on GitHub (after G-03)
+
+[PROGRESS] Mark Step 6/8 `in_progress`: `Step 6/8: Create on GitHub (after G-03) [in_progress]`
 
 **6a. Create milestones** (in order):
 [PARALLEL][FAST-MODEL] Create all milestones simultaneously:
@@ -147,9 +190,14 @@ gh api graphql -f query="mutation { addProjectV2ItemById(input: { projectId: \"{
 gh api graphql -f query="mutation { updateProjectV2ItemFieldValue(input: { projectId: \"{config.github.project_id}\", itemId: \"<item-id>\", fieldId: \"{config.github.status_field_id}\", value: { singleSelectOptionId: \"{config.github.statuses.todo}\" } }) { projectV2Item { id } } }"
 ```
 
+[PROGRESS] Mark Step 6/8 `completed`: `Step 6/8: Create on GitHub (after G-03) [completed]`
+`Milestones and issues created on GitHub`
+
 ---
 
 ## STEP 7 — Summary
+
+[PROGRESS] Mark Step 7/8 `in_progress`: `Step 7/8: Summary [in_progress]`
 
 ```
 ✓ Milestones created : <count>
@@ -163,11 +211,19 @@ Milestones:
 Project board: <board-url>
 ```
 
+[PROGRESS] Mark Step 7/8 `completed`: `Step 7/8: Summary [completed]`
+`Output displayed`
+
 ---
 
 ## STEP 8 — Handoff
+
+[PROGRESS] Mark Step 8/8 `in_progress`: `Step 8/8: Handoff [in_progress]`
 
 ```
 Release plan is live on GitHub.
 Next step: run /dev-start #<first-issue-number> to begin development.
 ```
+
+[PROGRESS] Mark Step 8/8 `completed`: `Step 8/8: Handoff [completed]`
+`Output displayed`

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -4,7 +4,7 @@
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 1 | Add `[PROGRESS]` marker to `references/claude-tools.md` | pending |
+| 1 | Add `[PROGRESS]` marker to `references/claude-tools.md` | done |
 | 2 | Instrument `dev-implement/SKILL.md` | pending |
 | 3 | Instrument `dev-parallel/SKILL.md` | pending |
 | 4 | Instrument `dev-plan/SKILL.md` | pending |
@@ -130,7 +130,7 @@ and graceful degradation behavior.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -7,7 +7,7 @@
 | 1 | Add `[PROGRESS]` marker to `references/claude-tools.md` | done |
 | 2 | Instrument `dev-implement/SKILL.md` | done |
 | 3 | Instrument `dev-parallel/SKILL.md` | done |
-| 4 | Instrument `dev-plan/SKILL.md` | pending |
+| 4 | Instrument `dev-plan/SKILL.md` | done |
 | 5 | Instrument `project-plan/SKILL.md` | pending |
 | 6 | Instrument `release-plan/SKILL.md` | pending |
 | 7 | Instrument `dev-release/SKILL.md` | pending |
@@ -411,7 +411,7 @@ then completed.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -9,7 +9,7 @@
 | 3 | Instrument `dev-parallel/SKILL.md` | done |
 | 4 | Instrument `dev-plan/SKILL.md` | done |
 | 5 | Instrument `project-plan/SKILL.md` | done |
-| 6 | Instrument `release-plan/SKILL.md` | pending |
+| 6 | Instrument `release-plan/SKILL.md` | done |
 | 7 | Instrument `dev-release/SKILL.md` | pending |
 
 ---
@@ -565,7 +565,7 @@ then completed.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -5,7 +5,7 @@
 | Step | Description | Status |
 |------|-------------|--------|
 | 1 | Add `[PROGRESS]` marker to `references/claude-tools.md` | done |
-| 2 | Instrument `dev-implement/SKILL.md` | pending |
+| 2 | Instrument `dev-implement/SKILL.md` | done |
 | 3 | Instrument `dev-parallel/SKILL.md` | pending |
 | 4 | Instrument `dev-plan/SKILL.md` | pending |
 | 5 | Instrument `project-plan/SKILL.md` | pending |
@@ -229,7 +229,7 @@ then completed with files/build/lint result.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -1,0 +1,661 @@
+# Implementation: Issue #8 — Add [PROGRESS] marker and TodoWrite integration to multi-step skills
+
+## Progress Table
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Add `[PROGRESS]` marker to `references/claude-tools.md` | pending |
+| 2 | Instrument `dev-implement/SKILL.md` | pending |
+| 3 | Instrument `dev-parallel/SKILL.md` | pending |
+| 4 | Instrument `dev-plan/SKILL.md` | pending |
+| 5 | Instrument `project-plan/SKILL.md` | pending |
+| 6 | Instrument `release-plan/SKILL.md` | pending |
+| 7 | Instrument `dev-release/SKILL.md` | pending |
+
+---
+
+## Conventions used throughout this doc
+
+### [in_progress] marker format
+Insert immediately **after** the `## STEP N — <title>` heading line (before the first line of that step's body):
+```
+[PROGRESS] Mark Step N/Total `in_progress`:
+`Step N/Total: <step title> [in_progress]`
+```
+
+### [completed] marker format
+Insert immediately **before** the `---` separator that closes the step:
+```
+[PROGRESS] Mark Step N/Total `completed`:
+`Step N/Total: <step title> [completed]`
+`<summary line — see per-step table in each step below>`
+```
+
+### Summary line rules
+| Step type | Summary line |
+|-----------|-------------|
+| Config load (reads .paadhai.json) | `Files read: .paadhai.json` |
+| Read files | `Files read: <list of files read>` |
+| Write/edit files | `Files changed: <list of files changed>` |
+| Analysis / decision / gate | `<one-word past-tense action, e.g. "Analysis complete", "Decision made", "Gate passed">` |
+| Shell commands (build/lint/test) | `Build: ✓  Lint: ✓  Tests: <count> passing` |
+| Display output to user | `Output displayed` |
+
+---
+
+## Step 1 — Add `[PROGRESS]` marker to `references/claude-tools.md`
+
+**File:** `references/claude-tools.md`
+
+### 1a — Extend the marker table
+
+In `references/claude-tools.md`, find this exact line:
+```
+| `[SMART-MODEL]` | `model: "opus"` parameter on Agent tool | Use most capable model |
+```
+
+Insert the following new row immediately after it:
+```
+| `[PROGRESS]` | `TodoWrite` tool | Create and update a live step checklist. Graceful degradation: skip if TodoWrite unavailable |
+```
+
+### 1b — Append [PROGRESS] Convention section
+
+Find this exact text at the end of the file:
+```
+No fallback needed — Claude Code supports all markers natively.
+```
+
+Insert the following block immediately after it (add a blank line before the new section):
+
+```markdown
+## [PROGRESS] Convention
+
+`[PROGRESS]` maps to the `TodoWrite` tool. Use it to maintain a live checklist of steps during skill execution.
+
+### Initialization (at skill start, after config is loaded)
+
+Create one TodoWrite item per numbered STEP in the skill. All items start as `pending`.
+
+Item format:
+```
+Step N/Total: <step title>
+```
+
+### Updating items during execution
+
+At the **start** of each step — update that item to `in_progress`:
+```
+Step 3/10: Analyze Task Dependencies [in_progress]
+```
+
+At the **end** of each step — update that item to `completed`, embedding result:
+```
+Step 3/10: Analyze Task Dependencies [completed]
+Analysis complete
+```
+
+For steps that read files:
+```
+Step 2/10: Load Implementation Doc [completed]
+Files read: docs/plans/issue-8/implementation.md, docs/plans/issue-8/plan.md
+```
+
+For steps that change files or run build/lint:
+```
+Step 7/10: Implementation Loop [completed]
+Files changed: src/auth.ts, src/types.ts
+Build: ✓  Lint: ✓
+```
+
+### Graceful degradation
+
+If the TodoWrite tool is unavailable, skip all `[PROGRESS]` calls silently and continue execution. Never block on progress tracking.
+```
+
+**Verification:**
+```bash
+grep -c "PROGRESS" references/claude-tools.md
+```
+Expected output: `3` (one in the table row, one in the section heading, one in the "Subagent Support" area — or at minimum `2` for table row + section heading).
+
+**Commit:**
+```bash
+git add references/claude-tools.md
+git commit -m "docs(markers): add [PROGRESS] marker mapping to TodoWrite tool
+
+Defines item format, in_progress/completed update convention,
+and graceful degradation behavior.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Step 2 — Instrument `dev-implement/SKILL.md`
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+
+### 2a — Insert initialization block
+
+Find this exact text in STEP 1:
+```
+- `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
+```
+
+Insert the following block immediately after that line, before the `---` separator that opens STEP 2:
+
+```markdown
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 10 items, all `pending`:
+```
+Step 1/10: Load Config
+Step 2/10: Load Implementation Doc
+Step 3/10: Analyze Task Dependencies
+Step 4/10: Choose Execution Path
+Step 5/10: Pre-Implementation Check
+Step 6/10: Route Execution
+Step 7/10: Implementation Loop
+Step 8/10: Full Test Run
+Step 9/10: Summary
+Step 10/10: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/10 `completed`:
+```
+Step 1/10: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+### 2b — Per-step [PROGRESS] markers
+
+Apply `[in_progress]` at start and `[completed]` at end for STEP 2–10 using the exact text below.
+
+**STEP 2:**
+- Start: `[PROGRESS] Mark Step 2/10 \`in_progress\`: \`Step 2/10: Load Implementation Doc [in_progress]\``
+- End: `[PROGRESS] Mark Step 2/10 \`completed\`: \`Step 2/10: Load Implementation Doc [completed]\` \`Files read: docs/plans/issue-<n>/implementation.md, docs/plans/issue-<n>/plan.md\``
+
+**STEP 3:**
+- Start: `[PROGRESS] Mark Step 3/10 \`in_progress\`: \`Step 3/10: Analyze Task Dependencies [in_progress]\``
+- End: `[PROGRESS] Mark Step 3/10 \`completed\`: \`Step 3/10: Analyze Task Dependencies [completed]\` \`Analysis complete\``
+
+**STEP 4:**
+- Start: `[PROGRESS] Mark Step 4/10 \`in_progress\`: \`Step 4/10: Choose Execution Path [in_progress]\``
+- End: `[PROGRESS] Mark Step 4/10 \`completed\`: \`Step 4/10: Choose Execution Path [completed]\` \`Decision made\``
+
+**STEP 5:**
+- Start: `[PROGRESS] Mark Step 5/10 \`in_progress\`: \`Step 5/10: Pre-Implementation Check [in_progress]\``
+- End: `[PROGRESS] Mark Step 5/10 \`completed\`: \`Step 5/10: Pre-Implementation Check [completed]\` \`Branch verified, working tree clean\``
+
+**STEP 6:**
+- Start: `[PROGRESS] Mark Step 6/10 \`in_progress\`: \`Step 6/10: Route Execution [in_progress]\``
+- End: `[PROGRESS] Mark Step 6/10 \`completed\`: \`Step 6/10: Route Execution [completed]\` \`Route determined\``
+
+**STEP 7:**
+- Start: `[PROGRESS] Mark Step 7/10 \`in_progress\`: \`Step 7/10: Implementation Loop [in_progress]\``
+- End: `[PROGRESS] Mark Step 7/10 \`completed\`: \`Step 7/10: Implementation Loop [completed]\` \`Files changed: <list from step>  Build: ✓  Lint: ✓\``
+
+**STEP 8:**
+- Start: `[PROGRESS] Mark Step 8/10 \`in_progress\`: \`Step 8/10: Full Test Run [in_progress]\``
+- End: `[PROGRESS] Mark Step 8/10 \`completed\`: \`Step 8/10: Full Test Run [completed]\` \`Build: ✓  Lint: ✓  Tests: <count> passing\``
+
+**STEP 9:**
+- Start: `[PROGRESS] Mark Step 9/10 \`in_progress\`: \`Step 9/10: Summary [in_progress]\``
+- End: `[PROGRESS] Mark Step 9/10 \`completed\`: \`Step 9/10: Summary [completed]\` \`Output displayed\``
+
+**STEP 10:**
+- Start: `[PROGRESS] Mark Step 10/10 \`in_progress\`: \`Step 10/10: Handoff [in_progress]\``
+- End: `[PROGRESS] Mark Step 10/10 \`completed\`: \`Step 10/10: Handoff [completed]\` \`Output displayed\``
+
+**Verification:**
+```bash
+grep -c "PROGRESS" .claude/skills/dev-implement/SKILL.md
+```
+Expected: `20` (1 init + 1 step-1-complete + 9 steps × 2)
+
+**Commit:**
+```bash
+git add .claude/skills/dev-implement/SKILL.md
+git commit -m "feat(dev-implement): add TodoWrite [PROGRESS] step tracking
+
+Creates 10-item checklist at start; marks each step in_progress
+then completed with files/build/lint result.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Step 3 — Instrument `dev-parallel/SKILL.md`
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+### 3a — Insert initialization block
+
+Find this exact text in STEP 1:
+```
+- `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
+- `{config.repo.owner}` / `{config.repo.name}`
+```
+
+Insert the following block immediately after those lines, before the `---` separator that opens STEP 2:
+
+```markdown
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 14 items, all `pending`:
+```
+Step 1/14: Load Config
+Step 2/14: Load Implementation Doc
+Step 3/14: Group Independent Tasks
+Step 4/14: Generate Subagent Prompts
+Step 5/14: Dispatch Gate
+Step 6/14: Dispatch Subagents (after G-11)
+Step 7/14: Collect Results
+Step 8/14: Stage 1: Spec Compliance Review
+Step 9/14: Stage 2: Code Quality Review
+Step 10/14: Fix Loop
+Step 11/14: Update Implementation Doc
+Step 12/14: Full Test Run
+Step 13/14: Summary
+Step 14/14: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/14 `completed`:
+```
+Step 1/14: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+### 3b — Per-step [PROGRESS] markers
+
+Apply `[in_progress]` at start and `[completed]` at end for STEP 2–14:
+
+| STEP | in_progress text | completed summary |
+|------|-----------------|-------------------|
+| 2 | `Step 2/14: Load Implementation Doc [in_progress]` | `Files read: docs/plans/issue-<n>/implementation.md, docs/plans/issue-<n>/plan.md` |
+| 3 | `Step 3/14: Group Independent Tasks [in_progress]` | `Task groups identified` |
+| 4 | `Step 4/14: Generate Subagent Prompts [in_progress]` | `Prompts generated` |
+| 5 | `Step 5/14: Dispatch Gate [in_progress]` | `Gate passed` |
+| 6 | `Step 6/14: Dispatch Subagents (after G-11) [in_progress]` | `Subagents dispatched` |
+| 7 | `Step 7/14: Collect Results [in_progress]` | `Results collected` |
+| 8 | `Step 8/14: Stage 1: Spec Compliance Review [in_progress]` | `Spec review: PASS` |
+| 9 | `Step 9/14: Stage 2: Code Quality Review [in_progress]` | `Code review: PASS` |
+| 10 | `Step 10/14: Fix Loop [in_progress]` | `Fixes applied` |
+| 11 | `Step 11/14: Update Implementation Doc [in_progress]` | `Files changed: docs/plans/issue-<n>/implementation.md` |
+| 12 | `Step 12/14: Full Test Run [in_progress]` | `Build: ✓  Lint: ✓  Tests: <count> passing` |
+| 13 | `Step 13/14: Summary [in_progress]` | `Output displayed` |
+| 14 | `Step 14/14: Handoff [in_progress]` | `Output displayed` |
+
+Each entry inserts:
+- After heading: `[PROGRESS] Mark Step N/14 \`in_progress\`: \`<in_progress text>\``
+- Before `---`: `[PROGRESS] Mark Step N/14 \`completed\`: \`<in_progress text with [in_progress] replaced by [completed]>\` \`<completed summary>\``
+
+**Verification:**
+```bash
+grep -c "PROGRESS" .claude/skills/dev-parallel/SKILL.md
+```
+Expected: `28` (1 init + 1 step-1-complete + 13 steps × 2)
+
+**Commit:**
+```bash
+git add .claude/skills/dev-parallel/SKILL.md
+git commit -m "feat(dev-parallel): add TodoWrite [PROGRESS] step tracking
+
+Creates 14-item checklist at start; marks each step in_progress
+then completed.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Step 4 — Instrument `dev-plan/SKILL.md`
+
+**File:** `.claude/skills/dev-plan/SKILL.md`
+
+### 4a — Insert initialization block
+
+Find this exact text in STEP 1:
+```
+- `{config.repo.develop_branch}`
+- `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
+```
+
+Insert the following block immediately after those lines, before the `---` separator that opens STEP 2:
+
+```markdown
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 17 items, all `pending`:
+```
+Step 1/17: Load Config
+Step 2/17: Identify Issue
+Step 3/17: Read Relevant Code
+Step 4/17: Scope Validation
+Step 5/17: Brainstorming Questions
+Step 6/17: Design Review
+Step 7/17: Security Threat Assessment
+Step 8/17: Version Validation
+Step 9/17: Generate Plan
+Step 10/17: Present Plan
+Step 11/17: Confirmation Loop
+Step 12/17: Save Plan
+Step 13/17: Generate Implementation Doc
+Step 14/17: Review Implementation Doc
+Step 15/17: User Confirms Implementation Doc
+Step 16/17: Commit
+Step 17/17: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/17 `completed`:
+```
+Step 1/17: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+### 4b — Per-step [PROGRESS] markers
+
+Apply `[in_progress]` at start and `[completed]` at end for STEP 2–17:
+
+| STEP | in_progress text | completed summary |
+|------|-----------------|-------------------|
+| 2 | `Step 2/17: Identify Issue [in_progress]` | `Issue details fetched` |
+| 3 | `Step 3/17: Read Relevant Code [in_progress]` | `Files read: <list of files read>` |
+| 4 | `Step 4/17: Scope Validation [in_progress]` | `Scope validated` |
+| 5 | `Step 5/17: Brainstorming Questions [in_progress]` | `Questions asked` |
+| 6 | `Step 6/17: Design Review [in_progress]` | `Design review complete` |
+| 7 | `Step 7/17: Security Threat Assessment [in_progress]` | `Security assessment complete` |
+| 8 | `Step 8/17: Version Validation [in_progress]` | `Version validation complete` |
+| 9 | `Step 9/17: Generate Plan [in_progress]` | `Plan generated` |
+| 10 | `Step 10/17: Present Plan [in_progress]` | `Plan presented` |
+| 11 | `Step 11/17: Confirmation Loop [in_progress]` | `Plan approved` |
+| 12 | `Step 12/17: Save Plan [in_progress]` | `Files changed: docs/plans/issue-<n>/plan.md` |
+| 13 | `Step 13/17: Generate Implementation Doc [in_progress]` | `Files changed: docs/plans/issue-<n>/implementation.md` |
+| 14 | `Step 14/17: Review Implementation Doc [in_progress]` | `Review: PASS` |
+| 15 | `Step 15/17: User Confirms Implementation Doc [in_progress]` | `Implementation doc approved` |
+| 16 | `Step 16/17: Commit [in_progress]` | `Committed: docs/plans/issue-<n>/` |
+| 17 | `Step 17/17: Handoff [in_progress]` | `Output displayed` |
+
+Each entry inserts:
+- After heading: `[PROGRESS] Mark Step N/17 \`in_progress\`: \`<in_progress text>\``
+- Before `---`: `[PROGRESS] Mark Step N/17 \`completed\`: \`<in_progress text with [in_progress] replaced by [completed]>\` \`<completed summary>\``
+
+**Verification:**
+```bash
+grep -c "PROGRESS" .claude/skills/dev-plan/SKILL.md
+```
+Expected: `34` (1 init + 1 step-1-complete + 16 steps × 2)
+
+**Commit:**
+```bash
+git add .claude/skills/dev-plan/SKILL.md
+git commit -m "feat(dev-plan): add TodoWrite [PROGRESS] step tracking
+
+Creates 17-item checklist at start; marks each step in_progress
+then completed.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Step 5 — Instrument `project-plan/SKILL.md`
+
+**File:** `.claude/skills/project-plan/SKILL.md`
+
+### 5a — Insert initialization block
+
+Find this exact text in STEP 1:
+```
+- If `project_version` absent → `{srs_path}` = `docs/srs.md`
+```
+
+Insert the following block immediately after that line, before the `---` separator that opens STEP 2:
+
+```markdown
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 10 items, all `pending`:
+```
+Step 1/10: Load Config
+Step 2/10: Read Existing Context
+Step 3/10: Product Description
+Step 4/10: Clarifying Questions
+Step 5/10: Research
+Step 6/10: Generate SRS
+Step 7/10: Present SRS
+Step 8/10: Revision Loop
+Step 9/10: Save
+Step 10/10: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/10 `completed`:
+```
+Step 1/10: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+### 5b — Per-step [PROGRESS] markers
+
+Apply `[in_progress]` at start and `[completed]` at end for STEP 2–10:
+
+| STEP | in_progress text | completed summary |
+|------|-----------------|-------------------|
+| 2 | `Step 2/10: Read Existing Context [in_progress]` | `Files read: <existing docs found>` |
+| 3 | `Step 3/10: Product Description [in_progress]` | `Description received` |
+| 4 | `Step 4/10: Clarifying Questions [in_progress]` | `Answers received` |
+| 5 | `Step 5/10: Research [in_progress]` | `Research complete` |
+| 6 | `Step 6/10: Generate SRS [in_progress]` | `SRS generated` |
+| 7 | `Step 7/10: Present SRS [in_progress]` | `SRS presented` |
+| 8 | `Step 8/10: Revision Loop [in_progress]` | `SRS approved` |
+| 9 | `Step 9/10: Save [in_progress]` | `Files changed: {srs_path}` |
+| 10 | `Step 10/10: Handoff [in_progress]` | `Output displayed` |
+
+Each entry inserts:
+- After heading: `[PROGRESS] Mark Step N/10 \`in_progress\`: \`<in_progress text>\``
+- Before `---`: `[PROGRESS] Mark Step N/10 \`completed\`: \`<in_progress text with [in_progress] replaced by [completed]>\` \`<completed summary>\``
+
+**Verification:**
+```bash
+grep -c "PROGRESS" .claude/skills/project-plan/SKILL.md
+```
+Expected: `20` (1 init + 1 step-1-complete + 9 steps × 2)
+
+**Commit:**
+```bash
+git add .claude/skills/project-plan/SKILL.md
+git commit -m "feat(project-plan): add TodoWrite [PROGRESS] step tracking
+
+Creates 10-item checklist at start; marks each step in_progress
+then completed.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Step 6 — Instrument `release-plan/SKILL.md`
+
+**File:** `.claude/skills/release-plan/SKILL.md`
+
+### 6a — Insert initialization block
+
+Find this exact text in STEP 1:
+```
+- `{config.project_version}` (if present)
+```
+
+Insert the following block immediately after that line, before the `---` separator that opens STEP 2:
+
+```markdown
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 8 items, all `pending`:
+```
+Step 1/8: Load Config + SRS
+Step 2/8: Analyze Requirements
+Step 3/8: Create Issues
+Step 4/8: Present Release Plan
+Step 5/8: Revision Loop
+Step 6/8: Create on GitHub (after G-03)
+Step 7/8: Summary
+Step 8/8: Handoff
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/8 `completed`:
+```
+Step 1/8: Load Config + SRS [completed]
+Files read: .paadhai.json, docs/srs-v{project_version}.md
+```
+```
+
+### 6b — Per-step [PROGRESS] markers
+
+Apply `[in_progress]` at start and `[completed]` at end for STEP 2–8:
+
+| STEP | in_progress text | completed summary |
+|------|-----------------|-------------------|
+| 2 | `Step 2/8: Analyze Requirements [in_progress]` | `Requirements analyzed` |
+| 3 | `Step 3/8: Create Issues [in_progress]` | `Issue list created` |
+| 4 | `Step 4/8: Present Release Plan [in_progress]` | `Plan presented` |
+| 5 | `Step 5/8: Revision Loop [in_progress]` | `Plan approved` |
+| 6 | `Step 6/8: Create on GitHub (after G-03) [in_progress]` | `Milestones and issues created on GitHub` |
+| 7 | `Step 7/8: Summary [in_progress]` | `Output displayed` |
+| 8 | `Step 8/8: Handoff [in_progress]` | `Output displayed` |
+
+Each entry inserts:
+- After heading: `[PROGRESS] Mark Step N/8 \`in_progress\`: \`<in_progress text>\``
+- Before `---`: `[PROGRESS] Mark Step N/8 \`completed\`: \`<in_progress text with [in_progress] replaced by [completed]>\` \`<completed summary>\``
+
+**Verification:**
+```bash
+grep -c "PROGRESS" .claude/skills/release-plan/SKILL.md
+```
+Expected: `16` (1 init + 1 step-1-complete + 7 steps × 2)
+
+**Commit:**
+```bash
+git add .claude/skills/release-plan/SKILL.md
+git commit -m "feat(release-plan): add TodoWrite [PROGRESS] step tracking
+
+Creates 8-item checklist at start; marks each step in_progress
+then completed.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Step 7 — Instrument `dev-release/SKILL.md`
+
+**File:** `.claude/skills/dev-release/SKILL.md`
+
+### 7a — Insert initialization block
+
+Find this exact text in STEP 1:
+```
+- `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` / `{config.stack.test_cmd}`
+```
+
+Insert the following block immediately after that line, before the `---` separator that opens STEP 2:
+
+```markdown
+### Progress Tracking
+
+[PROGRESS] Initialize TodoWrite checklist — 14 items, all `pending`:
+```
+Step 1/14: Load Config
+Step 2/14: Verify Milestone Completion
+Step 3/14: Ask Version
+Step 4/14: Prepare Release Branch
+Step 5/14: Run Full Test Suite
+Step 6/14: Generate Changelog
+Step 7/14: Push + Create Release PR
+Step 8/14: Display Release PR URL
+Step 9/14: Final Confirmation
+Step 10/14: Execute Release (after G-10)
+Step 11/14: Close Milestone
+Step 12/14: Display Release URL
+Step 13/14: Post-Release Health Check
+Step 14/14: Next Milestone
+```
+(Graceful degradation: skip if TodoWrite unavailable)
+
+[PROGRESS] Mark Step 1/14 `completed`:
+```
+Step 1/14: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+### 7b — Per-step [PROGRESS] markers
+
+Apply `[in_progress]` at start and `[completed]` at end for STEP 2–14:
+
+| STEP | in_progress text | completed summary |
+|------|-----------------|-------------------|
+| 2 | `Step 2/14: Verify Milestone Completion [in_progress]` | `Milestone verified: all issues closed` |
+| 3 | `Step 3/14: Ask Version [in_progress]` | `Version confirmed` |
+| 4 | `Step 4/14: Prepare Release Branch [in_progress]` | `Release branch created and pushed` |
+| 5 | `Step 5/14: Run Full Test Suite [in_progress]` | `Build: ✓  Lint: ✓  Tests: <count> passing` |
+| 6 | `Step 6/14: Generate Changelog [in_progress]` | `Files changed: CHANGELOG.md` |
+| 7 | `Step 7/14: Push + Create Release PR [in_progress]` | `PR created` |
+| 8 | `Step 8/14: Display Release PR URL [in_progress]` | `Output displayed` |
+| 9 | `Step 9/14: Final Confirmation [in_progress]` | `Gate passed` |
+| 10 | `Step 10/14: Execute Release (after G-10) [in_progress]` | `Release merged, tagged, back-merged` |
+| 11 | `Step 11/14: Close Milestone [in_progress]` | `Milestone closed` |
+| 12 | `Step 12/14: Display Release URL [in_progress]` | `Output displayed` |
+| 13 | `Step 13/14: Post-Release Health Check [in_progress]` | `Health check complete` |
+| 14 | `Step 14/14: Next Milestone [in_progress]` | `Output displayed` |
+
+Each entry inserts:
+- After heading: `[PROGRESS] Mark Step N/14 \`in_progress\`: \`<in_progress text>\``
+- Before `---`: `[PROGRESS] Mark Step N/14 \`completed\`: \`<in_progress text with [in_progress] replaced by [completed]>\` \`<completed summary>\``
+
+**Verification:**
+```bash
+grep -c "PROGRESS" .claude/skills/dev-release/SKILL.md
+```
+Expected: `28` (1 init + 1 step-1-complete + 13 steps × 2)
+
+**Commit:**
+```bash
+git add .claude/skills/dev-release/SKILL.md
+git commit -m "feat(dev-release): add TodoWrite [PROGRESS] step tracking
+
+Creates 14-item checklist at start; marks each step in_progress
+then completed.
+
+Refs #8"
+```
+
+**Status:** pending
+
+---
+
+## Deviations
+
+*(empty — record any deviations from the plan here during execution)*

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -10,7 +10,7 @@
 | 4 | Instrument `dev-plan/SKILL.md` | done |
 | 5 | Instrument `project-plan/SKILL.md` | done |
 | 6 | Instrument `release-plan/SKILL.md` | done |
-| 7 | Instrument `dev-release/SKILL.md` | pending |
+| 7 | Instrument `dev-release/SKILL.md` | done |
 
 ---
 
@@ -652,7 +652,7 @@ then completed.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -8,7 +8,7 @@
 | 2 | Instrument `dev-implement/SKILL.md` | done |
 | 3 | Instrument `dev-parallel/SKILL.md` | done |
 | 4 | Instrument `dev-plan/SKILL.md` | done |
-| 5 | Instrument `project-plan/SKILL.md` | pending |
+| 5 | Instrument `project-plan/SKILL.md` | done |
 | 6 | Instrument `release-plan/SKILL.md` | pending |
 | 7 | Instrument `dev-release/SKILL.md` | pending |
 
@@ -490,7 +490,7 @@ then completed.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/implementation.md
+++ b/docs/plans/issue-8/implementation.md
@@ -6,7 +6,7 @@
 |------|-------------|--------|
 | 1 | Add `[PROGRESS]` marker to `references/claude-tools.md` | done |
 | 2 | Instrument `dev-implement/SKILL.md` | done |
-| 3 | Instrument `dev-parallel/SKILL.md` | pending |
+| 3 | Instrument `dev-parallel/SKILL.md` | done |
 | 4 | Instrument `dev-plan/SKILL.md` | pending |
 | 5 | Instrument `project-plan/SKILL.md` | pending |
 | 6 | Instrument `release-plan/SKILL.md` | pending |
@@ -317,7 +317,7 @@ then completed.
 Refs #8"
 ```
 
-**Status:** pending
+**Status:** done
 
 ---
 

--- a/docs/plans/issue-8/plan.md
+++ b/docs/plans/issue-8/plan.md
@@ -1,0 +1,95 @@
+---
+issue: 8
+title: Add [PROGRESS] marker and TodoWrite integration to multi-step skills
+branch: feature/8-add-progress-marker-todowrite-skills
+milestone: v2.1 — Visibility
+status: confirmed
+confirmed_at: 2026-04-08T00:00:00Z
+---
+
+## Overview
+
+Add a `[PROGRESS]` capability marker to `references/claude-tools.md` and instrument 6 affected skills (`dev-implement`, `dev-parallel`, `dev-plan`, `project-plan`, `release-plan`, `dev-release`) with TodoWrite-based step tracking at the start of each skill's execution, updating each item's status and content as steps progress.
+
+## Files to Create
+
+None.
+
+## Files to Modify
+
+- `references/claude-tools.md` — Add `[PROGRESS]` marker row mapping to TodoWrite tool, with graceful-degradation note
+- `.claude/skills/dev-implement/SKILL.md` — Add `[PROGRESS]` checklist initialization after Step 1; update each step to mark `in_progress` at start and `completed` (with files/build/lint) at end
+- `.claude/skills/dev-parallel/SKILL.md` — Same pattern; `[PROGRESS]` init after Step 1; mark steps through Step 14
+- `.claude/skills/dev-plan/SKILL.md` — Same pattern; Steps 1–17
+- `.claude/skills/project-plan/SKILL.md` — Same pattern; Steps 1–10
+- `.claude/skills/release-plan/SKILL.md` — Same pattern; Steps 1–8
+- `.claude/skills/dev-release/SKILL.md` — Same pattern; Steps 1–14
+
+## Implementation Steps
+
+1. **Add `[PROGRESS]` marker to `references/claude-tools.md`**
+   - Append a new row to the marker table: `| \`[PROGRESS]\` | \`TodoWrite\` tool | Create and update a live step checklist. Graceful degradation: skip if TodoWrite unavailable |`
+   - Add a `[PROGRESS]` section under "Subagent Support" documenting item format and completion update convention
+   - Expected: file has 9 rows in the marker table; `[PROGRESS]` is the last row
+
+2. **Instrument `dev-implement/SKILL.md`**
+   - After STEP 1 body, insert a `[PROGRESS]` block that creates a 10-item TodoWrite list (one per STEP 1–10), all `pending`, using format `Step N/10: <step title>`
+   - At the start of each STEP (2–10), add a `[PROGRESS]` line marking that step `in_progress`
+   - At the end of each STEP (2–10), add a `[PROGRESS]` line marking it `completed` with files changed and build/lint result
+   - Expected: 10-item TodoWrite list is created; each step transitions `pending → in_progress → completed`
+
+3. **Instrument `dev-parallel/SKILL.md`**
+   - Same pattern as step 2; 14-item list (STEP 1–14)
+   - Expected: 14-item list; correct transitions per step
+
+4. **Instrument `dev-plan/SKILL.md`**
+   - Same pattern; 17-item list (STEP 1–17)
+   - Expected: 17-item list; correct transitions
+
+5. **Instrument `project-plan/SKILL.md`**
+   - Same pattern; 10-item list (STEP 1–10)
+   - Expected: 10-item list; correct transitions
+
+6. **Instrument `release-plan/SKILL.md`**
+   - Same pattern; 8-item list (STEP 1–8)
+   - Expected: 8-item list; correct transitions
+
+7. **Instrument `dev-release/SKILL.md`**
+   - Same pattern; 14-item list (STEP 1–14)
+   - Expected: 14-item list; correct transitions
+
+## Test Cases
+
+- **Happy path:** Run `dev-implement` on a multi-step plan — TodoWrite list of 10 items appears immediately; as each step executes, prior items show `completed` with files/build/lint; current step shows `in_progress`
+- **Edge case (single-step skill):** A skill with 1 step still creates a 1-item TodoWrite list
+- **Error case:** Step fails mid-execution — the failed step is NOT marked `completed`; remaining steps stay `pending`; skill does not proceed until failure is resolved
+
+## Security Considerations
+
+No security-relevant attack surfaces identified for this issue. These are markdown instruction files with no runtime code execution or user input handling.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|---------------|
+| AC-1 | `[PROGRESS]` marker added to `references/claude-tools.md` mapping to TodoWrite |
+| AC-2 | Each affected skill creates TodoWrite list at start with one item per numbered STEP |
+| AC-3 | Current step marked `in_progress`; all prior steps marked `completed` |
+| AC-4 | Completed items updated with files changed and build/lint result inline |
+| AC-5 | TodoWrite checklist is always visible in Claude Code's task panel — no scrolling needed |
+
+## Definition of Done
+
+- [ ] All ACs checked
+- [ ] All 6 skills + `references/claude-tools.md` updated
+- [ ] No hardcoded repo names or branch names in any modified file
+
+## Notes
+
+- ADR: declined (no new technology, no architectural decision — purely additive markdown changes)
+- Decisions locked in:
+  - Item format: `Step N/Total: <step title>` with `[in_progress]`/`[completed]` suffix
+  - Files/build/lint embedded inside completed todo item content
+  - Graceful degradation via inline `[PROGRESS]` note — no explicit availability check block
+  - Single-step skills still create a 1-item list
+  - All numbered STEPs tracked (including Load Config and Handoff); sub-steps (e.g., 7a, 7b) not counted separately

--- a/docs/plans/issue-8/test-plan.md
+++ b/docs/plans/issue-8/test-plan.md
@@ -1,0 +1,70 @@
+## Test Plan — Issue #8: Add [PROGRESS] marker and TodoWrite integration to multi-step skills
+
+### Test Framework: None (markdown/shell — grep-based content verification)
+
+### Test Stub File: `tests/verify-issue-8.sh`
+
+---
+
+### Test Cases
+
+#### Happy Path
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----|-------------|-------|---------|
+| TC-01 | AC-1 | content | `[PROGRESS]` marker row exists in `references/claude-tools.md` | `grep "\[PROGRESS\]" references/claude-tools.md` | ≥1 match |
+| TC-02 | AC-1 | content | `[PROGRESS]` section header exists in `references/claude-tools.md` | `grep "## \[PROGRESS\]" references/claude-tools.md` | ≥1 match |
+| TC-03 | AC-1 | content | Graceful degradation note present in `references/claude-tools.md` | `grep -i "graceful" references/claude-tools.md` | ≥1 match |
+| TC-04 | AC-2 | content | `dev-implement` contains PROGRESS init block + per-step markers | `grep -c "PROGRESS" .claude/skills/dev-implement/SKILL.md` | ≥20 |
+| TC-05 | AC-2 | content | `dev-parallel` contains PROGRESS init block + per-step markers | `grep -c "PROGRESS" .claude/skills/dev-parallel/SKILL.md` | ≥28 |
+| TC-06 | AC-2 | content | `dev-plan` contains PROGRESS init block + per-step markers | `grep -c "PROGRESS" .claude/skills/dev-plan/SKILL.md` | ≥34 |
+| TC-07 | AC-2 | content | `project-plan` contains PROGRESS init block + per-step markers | `grep -c "PROGRESS" .claude/skills/project-plan/SKILL.md` | ≥20 |
+| TC-08 | AC-2 | content | `release-plan` contains PROGRESS init block + per-step markers | `grep -c "PROGRESS" .claude/skills/release-plan/SKILL.md` | ≥16 |
+| TC-09 | AC-2 | content | `dev-release` contains PROGRESS init block + per-step markers | `grep -c "PROGRESS" .claude/skills/dev-release/SKILL.md` | ≥28 |
+| TC-10 | AC-3 | content | `dev-implement` has `[in_progress]` per-step markers (steps 2–10) | `grep -c "in_progress" .claude/skills/dev-implement/SKILL.md` | ≥9 |
+| TC-11 | AC-4 | content | `dev-implement` has `[completed]` per-step markers (steps 2–10) | `grep -c "completed" .claude/skills/dev-implement/SKILL.md` | ≥9 |
+| TC-12 | AC-4 | content | `dev-implement` completed format includes `Files:` field | `grep "Files:" .claude/skills/dev-implement/SKILL.md` | ≥1 match |
+| TC-13 | AC-4 | content | `dev-implement` completed format includes `Build:` field | `grep "Build:" .claude/skills/dev-implement/SKILL.md` | ≥1 match |
+
+#### Edge Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----|-------------|-------|---------|
+| TC-14 | AC-2 | content | `dev-implement` init block last item is `Step 10/10:` | `grep "Step 10/10:" .claude/skills/dev-implement/SKILL.md` | ≥1 match |
+| TC-15 | AC-2 | content | `dev-parallel` init block last item is `Step 14/14:` | `grep "Step 14/14:" .claude/skills/dev-parallel/SKILL.md` | ≥1 match |
+| TC-16 | AC-2 | content | `dev-plan` init block last item is `Step 17/17:` | `grep "Step 17/17:" .claude/skills/dev-plan/SKILL.md` | ≥1 match |
+| TC-17 | AC-2 | content | `project-plan` init block last item is `Step 10/10:` | `grep "Step 10/10:" .claude/skills/project-plan/SKILL.md` | ≥1 match |
+| TC-18 | AC-2 | content | `release-plan` init block last item is `Step 8/8:` | `grep "Step 8/8:" .claude/skills/release-plan/SKILL.md` | ≥1 match |
+| TC-19 | AC-2 | content | `dev-release` init block last item is `Step 14/14:` | `grep "Step 14/14:" .claude/skills/dev-release/SKILL.md` | ≥1 match |
+| TC-20 | AC-2 | content | Init block uses correct `Step N/Total:` format in `dev-implement` | `grep "Step 1/10:" .claude/skills/dev-implement/SKILL.md` | ≥1 match |
+
+#### Error / Failure Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----|-------------|-------|---------|
+| TC-21 | AC-2 | content | `dev-implement` init block does NOT use wrong total | `grep -E "Step 1/(9\|11):" .claude/skills/dev-implement/SKILL.md` | 0 matches |
+| TC-22 | AC-3 | content | No step has both `in_progress` and `completed` on the same line | `grep -E "in_progress.*completed\|completed.*in_progress" ...SKILL.md` | 0 matches |
+| TC-23 | AC-1 | content | `[PROGRESS]` table row appears exactly once in `claude-tools.md` | Count `^\| \`[PROGRESS]\`` rows | exactly 1 |
+| TC-24 | AC-4 | content | `Files:` field does not contain hardcoded `src/` path | `grep "Files: src/" .claude/skills/dev-implement/SKILL.md` | 0 matches |
+
+---
+
+### Coverage Target
+- All 5 ACs: 100% structural coverage via grep checks
+- 24 test cases: 13 happy path / 7 edge case / 4 error case
+- Behavioral coverage (manual): happy path (run dev-implement, observe TodoWrite updates), edge (single-step), error (mid-step failure)
+
+---
+
+### Manual Behavioral Test Notes
+
+These cannot be automated — they require running a Paadhai skill inside Claude Code:
+
+**M-1 (Happy path):** Invoke `dev-implement` on any plan with ≥2 steps. Observe that:
+- A TodoWrite checklist appears immediately with one item per step
+- The current step shows `[in_progress]` suffix
+- Prior steps show `[completed]` with Files and Build summary
+
+**M-2 (Edge case — graceful degradation):** Verify that if TodoWrite fails silently, the skill continues rather than halting.
+
+**M-3 (Error case):** When a step fails mid-execution, the failed step must NOT be marked `completed`; all remaining steps stay `pending`.

--- a/references/claude-tools.md
+++ b/references/claude-tools.md
@@ -13,6 +13,7 @@ Loaded at session start via `CLAUDE.md`.
 | `[DELEGATE]` | `Agent` tool | Launch isolated subagent |
 | `[FAST-MODEL]` | `model: "haiku"` parameter on Agent tool | Use fastest available model |
 | `[SMART-MODEL]` | `model: "opus"` parameter on Agent tool | Use most capable model |
+| `[PROGRESS]` | `TodoWrite` tool | Create and update a live step checklist. Graceful degradation: skip if TodoWrite unavailable |
 
 ## Subagent Support
 
@@ -25,3 +26,46 @@ Claude Code fully supports subagent dispatch via the `Agent` tool.
 ## Fallback
 
 No fallback needed — Claude Code supports all markers natively.
+
+## [PROGRESS] Convention
+
+`[PROGRESS]` maps to the `TodoWrite` tool. Use it to maintain a live checklist of steps during skill execution.
+
+### Initialization (at skill start, after config is loaded)
+
+Create one TodoWrite item per numbered STEP in the skill. All items start as `pending`.
+
+Item format:
+```
+Step N/Total: <step title>
+```
+
+### Updating items during execution
+
+At the **start** of each step — update that item to `in_progress`:
+```
+Step 3/10: Analyze Task Dependencies [in_progress]
+```
+
+At the **end** of each step — update that item to `completed`, embedding result:
+```
+Step 3/10: Analyze Task Dependencies [completed]
+Analysis complete
+```
+
+For steps that read files:
+```
+Step 2/10: Load Implementation Doc [completed]
+Files read: docs/plans/issue-8/implementation.md, docs/plans/issue-8/plan.md
+```
+
+For steps that change files or run build/lint:
+```
+Step 7/10: Implementation Loop [completed]
+Files changed: src/auth.ts, src/types.ts
+Build: ✓  Lint: ✓
+```
+
+### Graceful degradation
+
+If the TodoWrite tool is unavailable, skip all `[PROGRESS]` calls silently and continue execution. Never block on progress tracking.

--- a/tests/verify-issue-8.sh
+++ b/tests/verify-issue-8.sh
@@ -3,7 +3,7 @@
 # Content verification for issue #8: Add [PROGRESS] marker and TodoWrite integration
 # Run from repo root: bash tests/verify-issue-8.sh
 
-set -euo pipefail
+set -uo pipefail
 
 PASS=0
 FAIL=0
@@ -17,9 +17,9 @@ check() {
 
   local ok=false
   case "$op" in
-    ge) [ "$actual" -ge "$expected" ] && ok=true ;;
-    eq) [ "$actual" -eq "$expected" ] && ok=true ;;
-    gt) [ "$actual" -gt "$expected" ] && ok=true ;;
+    ge) [ "$actual" -ge "$expected" ] 2>/dev/null && ok=true ;;
+    eq) [ "$actual" -eq "$expected" ] 2>/dev/null && ok=true ;;
+    gt) [ "$actual" -gt "$expected" ] 2>/dev/null && ok=true ;;
   esac
 
   if $ok; then
@@ -31,6 +31,19 @@ check() {
   fi
 }
 
+# grep_count: always returns a number, never causes script exit
+grep_count() {
+  grep -c "$1" "$2" 2>/dev/null || true
+}
+
+grep_count_fixed() {
+  grep -cF "$1" "$2" 2>/dev/null || true
+}
+
+grep_count_regex() {
+  grep -cE "$1" "$2" 2>/dev/null || true
+}
+
 echo ""
 echo "=== Issue #8 Content Verification ==="
 echo ""
@@ -40,55 +53,55 @@ echo "Happy Path"
 
 # TC-1: [PROGRESS] marker row in claude-tools.md
 check "TC-01" "[PROGRESS] marker row in references/claude-tools.md" \
-  "$(grep -c '\[PROGRESS\]' references/claude-tools.md || echo 0)" ge 1
+  "$(grep_count '\[PROGRESS\]' references/claude-tools.md)" ge 1
 
 # TC-2: [PROGRESS] section header in claude-tools.md
 check "TC-02" "[PROGRESS] section header in references/claude-tools.md" \
-  "$(grep -c '## \[PROGRESS\]' references/claude-tools.md || echo 0)" ge 1
+  "$(grep_count '## \[PROGRESS\]' references/claude-tools.md)" ge 1
 
 # TC-3: Graceful degradation note in claude-tools.md
 check "TC-03" "Graceful degradation note in references/claude-tools.md" \
-  "$(grep -ci 'graceful' references/claude-tools.md || echo 0)" ge 1
+  "$(grep_count_regex '[Gg]raceful' references/claude-tools.md)" ge 1
 
 # TC-4: dev-implement PROGRESS call count
-check "TC-04" "dev-implement: ≥20 PROGRESS markers" \
-  "$(grep -c 'PROGRESS' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 20
+check "TC-04" "dev-implement: >=20 PROGRESS markers" \
+  "$(grep_count 'PROGRESS' .claude/skills/dev-implement/SKILL.md)" ge 20
 
 # TC-5: dev-parallel PROGRESS call count
-check "TC-05" "dev-parallel: ≥28 PROGRESS markers" \
-  "$(grep -c 'PROGRESS' .claude/skills/dev-parallel/SKILL.md || echo 0)" ge 28
+check "TC-05" "dev-parallel: >=28 PROGRESS markers" \
+  "$(grep_count 'PROGRESS' .claude/skills/dev-parallel/SKILL.md)" ge 28
 
 # TC-6: dev-plan PROGRESS call count
-check "TC-06" "dev-plan: ≥34 PROGRESS markers" \
-  "$(grep -c 'PROGRESS' .claude/skills/dev-plan/SKILL.md || echo 0)" ge 34
+check "TC-06" "dev-plan: >=34 PROGRESS markers" \
+  "$(grep_count 'PROGRESS' .claude/skills/dev-plan/SKILL.md)" ge 34
 
 # TC-7: project-plan PROGRESS call count
-check "TC-07" "project-plan: ≥20 PROGRESS markers" \
-  "$(grep -c 'PROGRESS' .claude/skills/project-plan/SKILL.md || echo 0)" ge 20
+check "TC-07" "project-plan: >=20 PROGRESS markers" \
+  "$(grep_count 'PROGRESS' .claude/skills/project-plan/SKILL.md)" ge 20
 
 # TC-8: release-plan PROGRESS call count
-check "TC-08" "release-plan: ≥16 PROGRESS markers" \
-  "$(grep -c 'PROGRESS' .claude/skills/release-plan/SKILL.md || echo 0)" ge 16
+check "TC-08" "release-plan: >=16 PROGRESS markers" \
+  "$(grep_count 'PROGRESS' .claude/skills/release-plan/SKILL.md)" ge 16
 
 # TC-9: dev-release PROGRESS call count
-check "TC-09" "dev-release: ≥28 PROGRESS markers" \
-  "$(grep -c 'PROGRESS' .claude/skills/dev-release/SKILL.md || echo 0)" ge 28
+check "TC-09" "dev-release: >=28 PROGRESS markers" \
+  "$(grep_count 'PROGRESS' .claude/skills/dev-release/SKILL.md)" ge 28
 
 # TC-10: dev-implement has [in_progress] per-step markers
-check "TC-10" "dev-implement: ≥9 [in_progress] step markers" \
-  "$(grep -c 'in_progress' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 9
+check "TC-10" "dev-implement: >=9 [in_progress] step markers" \
+  "$(grep_count 'in_progress' .claude/skills/dev-implement/SKILL.md)" ge 9
 
 # TC-11: dev-implement has [completed] per-step markers
-check "TC-11" "dev-implement: ≥9 [completed] step markers" \
-  "$(grep -c 'completed' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 9
+check "TC-11" "dev-implement: >=9 [completed] step markers" \
+  "$(grep_count 'completed' .claude/skills/dev-implement/SKILL.md)" ge 9
 
-# TC-12: dev-implement completed format includes Files: field
-check "TC-12" "dev-implement: Files: field present in completed format" \
-  "$(grep -c 'Files:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+# TC-12: dev-implement completed format includes Files read: or Files changed:
+check "TC-12" "dev-implement: Files read:/changed: field in completed format" \
+  "$(grep_count_regex 'Files (read|changed):' .claude/skills/dev-implement/SKILL.md)" ge 1
 
 # TC-13: dev-implement completed format includes Build: field
 check "TC-13" "dev-implement: Build: field present in completed format" \
-  "$(grep -c 'Build:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Build:' .claude/skills/dev-implement/SKILL.md)" ge 1
 
 echo ""
 # ── Edge Cases ────────────────────────────────────────────────────────────────
@@ -96,31 +109,31 @@ echo "Edge Cases"
 
 # TC-14: dev-implement init block last item is Step 10/10
 check "TC-14" "dev-implement: init block contains Step 10/10:" \
-  "$(grep -c 'Step 10/10:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 10/10:' .claude/skills/dev-implement/SKILL.md)" ge 1
 
 # TC-15: dev-parallel init block last item is Step 14/14
 check "TC-15" "dev-parallel: init block contains Step 14/14:" \
-  "$(grep -c 'Step 14/14:' .claude/skills/dev-parallel/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 14/14:' .claude/skills/dev-parallel/SKILL.md)" ge 1
 
 # TC-16: dev-plan init block last item is Step 17/17
 check "TC-16" "dev-plan: init block contains Step 17/17:" \
-  "$(grep -c 'Step 17/17:' .claude/skills/dev-plan/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 17/17:' .claude/skills/dev-plan/SKILL.md)" ge 1
 
 # TC-17: project-plan init block last item is Step 10/10
 check "TC-17" "project-plan: init block contains Step 10/10:" \
-  "$(grep -c 'Step 10/10:' .claude/skills/project-plan/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 10/10:' .claude/skills/project-plan/SKILL.md)" ge 1
 
 # TC-18: release-plan init block last item is Step 8/8
 check "TC-18" "release-plan: init block contains Step 8/8:" \
-  "$(grep -c 'Step 8/8:' .claude/skills/release-plan/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 8/8:' .claude/skills/release-plan/SKILL.md)" ge 1
 
 # TC-19: dev-release init block last item is Step 14/14
 check "TC-19" "dev-release: init block contains Step 14/14:" \
-  "$(grep -c 'Step 14/14:' .claude/skills/dev-release/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 14/14:' .claude/skills/dev-release/SKILL.md)" ge 1
 
 # TC-20: dev-implement uses correct Step N/Total: format (Step 1/10:)
 check "TC-20" "dev-implement: Step 1/10: format present" \
-  "$(grep -c 'Step 1/10:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+  "$(grep_count 'Step 1/10:' .claude/skills/dev-implement/SKILL.md)" ge 1
 
 echo ""
 # ── Error / Failure Cases ─────────────────────────────────────────────────────
@@ -128,19 +141,19 @@ echo "Error / Failure Cases"
 
 # TC-21: dev-implement init block does NOT use wrong total (e.g. Step 1/9:, Step 1/11:)
 check "TC-21" "dev-implement: no wrong total in init block (not Step 1/9: or Step 1/11:)" \
-  "$(grep -cE 'Step 1/(9|11):' .claude/skills/dev-implement/SKILL.md || echo 0)" eq 0
+  "$(grep_count_regex 'Step 1/(9|11):' .claude/skills/dev-implement/SKILL.md)" eq 0
 
 # TC-22: No step has both in_progress and completed on the same line
 check "TC-22" "dev-implement: no line mixes in_progress + completed" \
-  "$(grep -cE 'in_progress.*completed|completed.*in_progress' .claude/skills/dev-implement/SKILL.md || echo 0)" eq 0
+  "$(grep_count_regex 'in_progress.*completed|completed.*in_progress' .claude/skills/dev-implement/SKILL.md)" eq 0
 
 # TC-23: [PROGRESS] marker row appears exactly once in the marker table of claude-tools.md
 check "TC-23" "claude-tools.md: [PROGRESS] table row appears exactly once" \
-  "$(grep -c '^\| \`\[PROGRESS\]\`' references/claude-tools.md || echo 0)" eq 1
+  "$(grep_count_fixed '| `[PROGRESS]`' references/claude-tools.md)" eq 1
 
 # TC-24: Files: in completed format is not hardcoded with a real path
 check "TC-24" "dev-implement: Files: field does not contain hardcoded src/ path" \
-  "$(grep -c 'Files: src/' .claude/skills/dev-implement/SKILL.md || echo 0)" eq 0
+  "$(grep_count_fixed 'Files: src/' .claude/skills/dev-implement/SKILL.md)" eq 0
 
 echo ""
 echo "══════════════════════════════════════"

--- a/tests/verify-issue-8.sh
+++ b/tests/verify-issue-8.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# verify-issue-8.sh
+# Content verification for issue #8: Add [PROGRESS] marker and TodoWrite integration
+# Run from repo root: bash tests/verify-issue-8.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local id="$1"
+  local description="$2"
+  local actual="$3"
+  local op="$4"
+  local expected="$5"
+
+  local ok=false
+  case "$op" in
+    ge) [ "$actual" -ge "$expected" ] && ok=true ;;
+    eq) [ "$actual" -eq "$expected" ] && ok=true ;;
+    gt) [ "$actual" -gt "$expected" ] && ok=true ;;
+  esac
+
+  if $ok; then
+    echo "  PASS [$id] $description (got $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [$id] $description (expected $op $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "=== Issue #8 Content Verification ==="
+echo ""
+
+# ── Happy Path ────────────────────────────────────────────────────────────────
+echo "Happy Path"
+
+# TC-1: [PROGRESS] marker row in claude-tools.md
+check "TC-01" "[PROGRESS] marker row in references/claude-tools.md" \
+  "$(grep -c '\[PROGRESS\]' references/claude-tools.md || echo 0)" ge 1
+
+# TC-2: [PROGRESS] section header in claude-tools.md
+check "TC-02" "[PROGRESS] section header in references/claude-tools.md" \
+  "$(grep -c '## \[PROGRESS\]' references/claude-tools.md || echo 0)" ge 1
+
+# TC-3: Graceful degradation note in claude-tools.md
+check "TC-03" "Graceful degradation note in references/claude-tools.md" \
+  "$(grep -ci 'graceful' references/claude-tools.md || echo 0)" ge 1
+
+# TC-4: dev-implement PROGRESS call count
+check "TC-04" "dev-implement: ≥20 PROGRESS markers" \
+  "$(grep -c 'PROGRESS' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 20
+
+# TC-5: dev-parallel PROGRESS call count
+check "TC-05" "dev-parallel: ≥28 PROGRESS markers" \
+  "$(grep -c 'PROGRESS' .claude/skills/dev-parallel/SKILL.md || echo 0)" ge 28
+
+# TC-6: dev-plan PROGRESS call count
+check "TC-06" "dev-plan: ≥34 PROGRESS markers" \
+  "$(grep -c 'PROGRESS' .claude/skills/dev-plan/SKILL.md || echo 0)" ge 34
+
+# TC-7: project-plan PROGRESS call count
+check "TC-07" "project-plan: ≥20 PROGRESS markers" \
+  "$(grep -c 'PROGRESS' .claude/skills/project-plan/SKILL.md || echo 0)" ge 20
+
+# TC-8: release-plan PROGRESS call count
+check "TC-08" "release-plan: ≥16 PROGRESS markers" \
+  "$(grep -c 'PROGRESS' .claude/skills/release-plan/SKILL.md || echo 0)" ge 16
+
+# TC-9: dev-release PROGRESS call count
+check "TC-09" "dev-release: ≥28 PROGRESS markers" \
+  "$(grep -c 'PROGRESS' .claude/skills/dev-release/SKILL.md || echo 0)" ge 28
+
+# TC-10: dev-implement has [in_progress] per-step markers
+check "TC-10" "dev-implement: ≥9 [in_progress] step markers" \
+  "$(grep -c 'in_progress' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 9
+
+# TC-11: dev-implement has [completed] per-step markers
+check "TC-11" "dev-implement: ≥9 [completed] step markers" \
+  "$(grep -c 'completed' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 9
+
+# TC-12: dev-implement completed format includes Files: field
+check "TC-12" "dev-implement: Files: field present in completed format" \
+  "$(grep -c 'Files:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+
+# TC-13: dev-implement completed format includes Build: field
+check "TC-13" "dev-implement: Build: field present in completed format" \
+  "$(grep -c 'Build:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+
+echo ""
+# ── Edge Cases ────────────────────────────────────────────────────────────────
+echo "Edge Cases"
+
+# TC-14: dev-implement init block last item is Step 10/10
+check "TC-14" "dev-implement: init block contains Step 10/10:" \
+  "$(grep -c 'Step 10/10:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+
+# TC-15: dev-parallel init block last item is Step 14/14
+check "TC-15" "dev-parallel: init block contains Step 14/14:" \
+  "$(grep -c 'Step 14/14:' .claude/skills/dev-parallel/SKILL.md || echo 0)" ge 1
+
+# TC-16: dev-plan init block last item is Step 17/17
+check "TC-16" "dev-plan: init block contains Step 17/17:" \
+  "$(grep -c 'Step 17/17:' .claude/skills/dev-plan/SKILL.md || echo 0)" ge 1
+
+# TC-17: project-plan init block last item is Step 10/10
+check "TC-17" "project-plan: init block contains Step 10/10:" \
+  "$(grep -c 'Step 10/10:' .claude/skills/project-plan/SKILL.md || echo 0)" ge 1
+
+# TC-18: release-plan init block last item is Step 8/8
+check "TC-18" "release-plan: init block contains Step 8/8:" \
+  "$(grep -c 'Step 8/8:' .claude/skills/release-plan/SKILL.md || echo 0)" ge 1
+
+# TC-19: dev-release init block last item is Step 14/14
+check "TC-19" "dev-release: init block contains Step 14/14:" \
+  "$(grep -c 'Step 14/14:' .claude/skills/dev-release/SKILL.md || echo 0)" ge 1
+
+# TC-20: dev-implement uses correct Step N/Total: format (Step 1/10:)
+check "TC-20" "dev-implement: Step 1/10: format present" \
+  "$(grep -c 'Step 1/10:' .claude/skills/dev-implement/SKILL.md || echo 0)" ge 1
+
+echo ""
+# ── Error / Failure Cases ─────────────────────────────────────────────────────
+echo "Error / Failure Cases"
+
+# TC-21: dev-implement init block does NOT use wrong total (e.g. Step 1/9:, Step 1/11:)
+check "TC-21" "dev-implement: no wrong total in init block (not Step 1/9: or Step 1/11:)" \
+  "$(grep -cE 'Step 1/(9|11):' .claude/skills/dev-implement/SKILL.md || echo 0)" eq 0
+
+# TC-22: No step has both in_progress and completed on the same line
+check "TC-22" "dev-implement: no line mixes in_progress + completed" \
+  "$(grep -cE 'in_progress.*completed|completed.*in_progress' .claude/skills/dev-implement/SKILL.md || echo 0)" eq 0
+
+# TC-23: [PROGRESS] marker row appears exactly once in the marker table of claude-tools.md
+check "TC-23" "claude-tools.md: [PROGRESS] table row appears exactly once" \
+  "$(grep -c '^\| \`\[PROGRESS\]\`' references/claude-tools.md || echo 0)" eq 1
+
+# TC-24: Files: in completed format is not hardcoded with a real path
+check "TC-24" "dev-implement: Files: field does not contain hardcoded src/ path" \
+  "$(grep -c 'Files: src/' .claude/skills/dev-implement/SKILL.md || echo 0)" eq 0
+
+echo ""
+echo "══════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "══════════════════════════════════════"
+echo ""
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Adds `[PROGRESS]` capability marker to `references/claude-tools.md` mapping to the `TodoWrite` native tool
- Instruments 6 multi-step skills (`dev-implement`, `dev-parallel`, `dev-plan`, `project-plan`, `release-plan`, `dev-release`) with live step checklists
- Each skill initializes a TodoWrite checklist on startup (all items `pending`), then marks each step `in_progress` at start and `completed` (with files/build/lint summary) at end
- Graceful degradation: skills continue silently if TodoWrite is unavailable
- Adds `tests/verify-issue-8.sh` with 24 grep-based content verification tests (all passing)

## Changes

- `references/claude-tools.md` — new `[PROGRESS]` table row + convention section
- `.claude/skills/dev-implement/SKILL.md` — 10-step TodoWrite checklist
- `.claude/skills/dev-parallel/SKILL.md` — 14-step TodoWrite checklist
- `.claude/skills/dev-plan/SKILL.md` — 17-step TodoWrite checklist
- `.claude/skills/project-plan/SKILL.md` — 10-step TodoWrite checklist
- `.claude/skills/release-plan/SKILL.md` — 8-step TodoWrite checklist
- `.claude/skills/dev-release/SKILL.md` — 14-step TodoWrite checklist
- `docs/plans/issue-8/` — plan, implementation doc, test plan
- `tests/verify-issue-8.sh` — content verification script

## Test Plan

No build/lint/test commands (markdown-only project). Verification via:
```bash
bash tests/verify-issue-8.sh
```
Result: **24/24 passing**

Test coverage:
- Happy path (TC-01–TC-13): PROGRESS markers present, correct counts, correct format fields
- Edge cases (TC-14–TC-20): correct step totals (Step N/N: format) in each skill
- Error/failure cases (TC-21–TC-24): no wrong totals, no mixed status lines, table row appears exactly once, no hardcoded paths

## Acceptance Criteria

- [x] AC-1: `[PROGRESS]` marker added to `references/claude-tools.md` mapping to TodoWrite
- [x] AC-2: Each affected skill creates TodoWrite list at start with one item per numbered STEP
- [x] AC-3: Current step marked `in_progress`; all prior steps marked `completed`
- [x] AC-4: Completed items updated with files changed and build/lint result inline
- [x] AC-5: TodoWrite checklist always visible in Claude Code's task panel

## Notes

- ADR: declined — purely additive markdown changes, no new technology or architectural decision
- Item format: `Step N/Total: <step title>` with `[in_progress]`/`[completed]` suffix
- Files/build/lint summary embedded inside completed item content (not separate fields)

Closes #8