### PR TITLE
feat(skills): implement skill invocation announcement banners

### DIFF
--- a/.claude/skills/dev-adr/SKILL.md
+++ b/.claude/skills/dev-adr/SKILL.md
@@ -11,6 +11,40 @@ Record architectural decisions with context, alternatives considered, rationale,
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-adr | Issue #<number> — <title>
+10 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-adr
+10 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-audit/SKILL.md
+++ b/.claude/skills/dev-audit/SKILL.md
@@ -11,6 +11,40 @@ Architecture, security, and compatibility review of the PR with explicit human s
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-audit | Issue #<number> — <title>
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-audit
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-debug/SKILL.md
+++ b/.claude/skills/dev-debug/SKILL.md
@@ -9,6 +9,40 @@ description: Use when debugging failures — 4-phase systematic debugging with e
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-debug | Issue #<number> — <title>
+11 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-debug
+11 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-deps/SKILL.md
+++ b/.claude/skills/dev-deps/SKILL.md
@@ -9,6 +9,23 @@ Scan project dependencies for security vulnerabilities, license compliance issue
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+dev-deps
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-docs/SKILL.md
+++ b/.claude/skills/dev-docs/SKILL.md
@@ -11,6 +11,40 @@ Generate API reference, user guide, or architecture documentation from the curre
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-docs | Issue #<number> — <title>
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-docs
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-hotfix/SKILL.md
+++ b/.claude/skills/dev-hotfix/SKILL.md
@@ -9,6 +9,40 @@ Create a hotfix branch from main, implement a minimal targeted fix, and open a P
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-hotfix | Issue #<number> — <title>
+12 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-hotfix
+12 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -18,6 +18,40 @@ If the user says "continue" or "resume":
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-implement | Issue #<number> — <title>
+10 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-implement
+10 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-parallel/SKILL.md
+++ b/.claude/skills/dev-parallel/SKILL.md
@@ -9,6 +9,40 @@ Dispatch independent implementation tasks to fresh subagents, review each for sp
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-parallel | Issue #<number> — <title>
+14 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-parallel
+14 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-plan/SKILL.md
+++ b/.claude/skills/dev-plan/SKILL.md
@@ -11,6 +11,40 @@ Brainstorm, design review, security assessment, version validation, generate pla
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-plan | Issue #<number> — <title>
+17 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-plan
+17 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-pr/SKILL.md
+++ b/.claude/skills/dev-pr/SKILL.md
@@ -11,6 +11,40 @@ Push the feature branch, create the pull request, poll CI, and report results.
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-pr | Issue #<number> — <title>
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-pr
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-release/SKILL.md
+++ b/.claude/skills/dev-release/SKILL.md
@@ -9,6 +9,23 @@ Cut the release branch, run tests, create PR to main, tag, publish GitHub Releas
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+dev-release
+14 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-rollback/SKILL.md
+++ b/.claude/skills/dev-rollback/SKILL.md
@@ -9,6 +9,40 @@ Recover from a bad release: delete the tag, revert the merge commit on main, cre
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-rollback | Issue #<number> — <title>
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-rollback
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-ship/SKILL.md
+++ b/.claude/skills/dev-ship/SKILL.md
@@ -11,6 +11,40 @@ Merge the approved PR, move issue to Done on the project board, clean up the fea
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-ship | Issue #<number> — <title>
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-ship
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-start/SKILL.md
+++ b/.claude/skills/dev-start/SKILL.md
@@ -11,6 +11,40 @@ Pick an issue, run pre-flight checks, create the feature branch, move the issue 
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-start | Issue #<number> — <title>
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-start
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-status/SKILL.md
+++ b/.claude/skills/dev-status/SKILL.md
@@ -11,6 +11,23 @@ Read-only status view: scan implementation docs, milestone stats, board columns.
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+dev-status
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-test/SKILL.md
+++ b/.claude/skills/dev-test/SKILL.md
@@ -11,6 +11,40 @@ Generate a test plan from acceptance criteria and write test file stubs before i
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-test | Issue #<number> — <title>
+11 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-test
+11 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-unblock/SKILL.md
+++ b/.claude/skills/dev-unblock/SKILL.md
@@ -9,6 +9,40 @@ Detect CI failure type or merge conflict, diagnose, fix, re-push, poll until gre
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-unblock | Issue #<number> — <title>
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-unblock
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/next-version/SKILL.md
+++ b/.claude/skills/next-version/SKILL.md
@@ -9,6 +9,23 @@ Bump project_version in .paadhai.json, validate semver, commit, and optionally c
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+next-version
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/paadhai-skill/SKILL.md
+++ b/.claude/skills/paadhai-skill/SKILL.md
@@ -9,6 +9,23 @@ Create new Paadhai skills with proper conventions, register them in CLAUDE.md an
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+paadhai-skill
+13 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/project-init/SKILL.md
+++ b/.claude/skills/project-init/SKILL.md
@@ -9,6 +9,23 @@ Set up a new or existing GitHub project, write `.paadhai.json`, create branches 
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+project-init
+9 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Verify Prerequisites
 
 [SHELL] Check GitHub CLI auth:

--- a/.claude/skills/project-plan/SKILL.md
+++ b/.claude/skills/project-plan/SKILL.md
@@ -11,6 +11,23 @@ Transform a product idea into a confirmed Software Requirements Specification do
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+project-plan
+10 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/release-plan/SKILL.md
+++ b/.claude/skills/release-plan/SKILL.md
@@ -11,6 +11,23 @@ Break the confirmed SRS into GitHub milestones and atomic issues, then create th
 
 ---
 
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+release-plan
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
 ## STEP 1 — Load Config + SRS
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/docs/plans/issue-9/implementation.md
+++ b/docs/plans/issue-9/implementation.md
@@ -9,8 +9,8 @@ status: pending
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 1 | Define preamble templates | pending |
-| 2 | Insert preamble into issue-aware skills (14 files) | pending |
+| 1 | Define preamble templates | done |
+| 2 | Insert preamble into issue-aware skills (14 files) | done |
 | 3 | Insert preamble into non-issue skills (8 files) | pending |
 | 4 | Verify all 22 skills have preamble | pending |
 

--- a/docs/plans/issue-9/implementation.md
+++ b/docs/plans/issue-9/implementation.md
@@ -11,7 +11,7 @@ status: pending
 |------|-------------|--------|
 | 1 | Define preamble templates | done |
 | 2 | Insert preamble into issue-aware skills (14 files) | done |
-| 3 | Insert preamble into non-issue skills (8 files) | pending |
+| 3 | Insert preamble into non-issue skills (8 files) | done |
 | 4 | Verify all 22 skills have preamble | pending |
 
 ---

--- a/docs/plans/issue-9/implementation.md
+++ b/docs/plans/issue-9/implementation.md
@@ -12,7 +12,7 @@ status: pending
 | 1 | Define preamble templates | done |
 | 2 | Insert preamble into issue-aware skills (14 files) | done |
 | 3 | Insert preamble into non-issue skills (8 files) | done |
-| 4 | Verify all 22 skills have preamble | pending |
+| 4 | Verify all 22 skills have preamble | done |
 
 ---
 

--- a/docs/plans/issue-9/implementation.md
+++ b/docs/plans/issue-9/implementation.md
@@ -1,0 +1,264 @@
+---
+issue: 9
+title: Implement skill invocation announcement banners
+branch: feature/9-skill-invocation-banners
+status: pending
+---
+
+## Progress
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Define preamble templates | pending |
+| 2 | Insert preamble into issue-aware skills (14 files) | pending |
+| 3 | Insert preamble into non-issue skills (8 files) | pending |
+| 4 | Verify all 22 skills have preamble | pending |
+
+---
+
+## Step 1 — Define preamble templates
+
+**Status:** pending
+
+Two preamble variants will be used. They are inserted between the last `---` before `## STEP 1` and `## STEP 1` itself in each SKILL.md.
+
+### Variant A: Issue-aware preamble
+
+Used for skills that typically run on a feature/fix branch tied to an issue:
+`dev-adr`, `dev-audit`, `dev-debug`, `dev-docs`, `dev-hotfix`, `dev-implement`, `dev-parallel`, `dev-plan`, `dev-pr`, `dev-ship`, `dev-start`, `dev-test`, `dev-unblock`, `dev-rollback`
+
+Template (placeholders `<SKILL-NAME>` and `<N>` are replaced per skill):
+
+```markdown
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+<SKILL-NAME> | Issue #<number> — <title>
+<N> steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+<SKILL-NAME>
+<N> steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+```
+
+### Variant B: Non-issue preamble
+
+Used for skills that don't operate on a specific issue:
+`dev-deps`, `dev-release`, `dev-status`, `next-version`, `paadhai-skill`, `project-init`, `project-plan`, `release-plan`
+
+Template:
+
+```markdown
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+<SKILL-NAME>
+<N> steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+```
+
+**Expected output:** Two reusable text templates ready for insertion. No files changed yet.
+
+---
+
+## Step 2 — Insert preamble into issue-aware skills (14 files)
+
+**Status:** pending
+
+For each of the following 14 skills, insert **Variant A** preamble between the last `---` separator and `## STEP 1`. Replace `<SKILL-NAME>` with the skill name and `<N>` with the step count.
+
+| Skill | Name in banner | Steps |
+|-------|---------------|-------|
+| `.claude/skills/dev-adr/SKILL.md` | dev-adr | 10 |
+| `.claude/skills/dev-audit/SKILL.md` | dev-audit | 7 |
+| `.claude/skills/dev-debug/SKILL.md` | dev-debug | 11 |
+| `.claude/skills/dev-docs/SKILL.md` | dev-docs | 8 |
+| `.claude/skills/dev-hotfix/SKILL.md` | dev-hotfix | 12 |
+| `.claude/skills/dev-implement/SKILL.md` | dev-implement | 10 |
+| `.claude/skills/dev-parallel/SKILL.md` | dev-parallel | 14 |
+| `.claude/skills/dev-plan/SKILL.md` | dev-plan | 17 |
+| `.claude/skills/dev-pr/SKILL.md` | dev-pr | 8 |
+| `.claude/skills/dev-ship/SKILL.md` | dev-ship | 7 |
+| `.claude/skills/dev-start/SKILL.md` | dev-start | 8 |
+| `.claude/skills/dev-test/SKILL.md` | dev-test | 11 |
+| `.claude/skills/dev-unblock/SKILL.md` | dev-unblock | 8 |
+| `.claude/skills/dev-rollback/SKILL.md` | dev-rollback | 8 |
+
+**Exact edit per file:** Find the `---` line immediately before `## STEP 1` and insert the preamble block after it (before `## STEP 1`).
+
+For example, in `dev-start/SKILL.md` (Step 1 at line 14), the edit replaces:
+
+```
+---
+
+## STEP 1 — Load Config
+```
+
+with:
+
+```
+---
+
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+If branch matches `feature/*` or `fix/*`:
+- Extract issue number from branch name (e.g., `feature/42-add-login` → `42`)
+- [SHELL] Fetch issue title:
+```bash
+gh api repos/{config.repo.owner}/{config.repo.name}/issues/<number> --jq '.title'
+```
+
+Display (with issue context):
+```
+────────────────────────────────────────
+dev-start | Issue #<number> — <title>
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+Display (no issue context — not on feature/fix branch):
+```
+────────────────────────────────────────
+dev-start
+8 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+If `gh api` fails, degrade gracefully — show banner without issue title.
+
+---
+
+## STEP 1 — Load Config
+```
+
+Repeat for all 14 skills, substituting skill name and step count per the table above.
+
+**Expected output:** 14 SKILL.md files modified, each containing `## PREAMBLE — Announcement Banner` before `## STEP 1`.
+
+---
+
+## Step 3 — Insert preamble into non-issue skills (8 files)
+
+**Status:** pending
+
+For each of the following 8 skills, insert **Variant B** preamble:
+
+| Skill | Name in banner | Steps |
+|-------|---------------|-------|
+| `.claude/skills/dev-deps/SKILL.md` | dev-deps | 8 |
+| `.claude/skills/dev-release/SKILL.md` | dev-release | 14 |
+| `.claude/skills/dev-status/SKILL.md` | dev-status | 7 |
+| `.claude/skills/next-version/SKILL.md` | next-version | 7 |
+| `.claude/skills/paadhai-skill/SKILL.md` | paadhai-skill | 13 |
+| `.claude/skills/project-init/SKILL.md` | project-init | 9 |
+| `.claude/skills/project-plan/SKILL.md` | project-plan | 10 |
+| `.claude/skills/release-plan/SKILL.md` | release-plan | 8 |
+
+**Exact edit per file:** Same insertion point — between `---` and `## STEP 1`.
+
+For example, in `dev-status/SKILL.md`:
+
+```
+---
+
+## PREAMBLE — Announcement Banner
+
+[SHELL] Detect context:
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+Display:
+```
+────────────────────────────────────────
+dev-status
+7 steps | Branch: <branch>
+────────────────────────────────────────
+```
+
+---
+
+## STEP 1 — Load Config
+```
+
+Repeat for all 8 skills with correct name and step count.
+
+**Expected output:** 8 SKILL.md files modified, each containing `## PREAMBLE — Announcement Banner` before `## STEP 1`.
+
+---
+
+## Step 4 — Verify all 22 skills have preamble
+
+**Status:** pending
+
+[SHELL] Count skills with preamble:
+```bash
+grep -rl "## PREAMBLE" .claude/skills/*/SKILL.md | wc -l
+```
+
+**Expected output:** `22`
+
+[SHELL] Verify no skill is missing:
+```bash
+for d in .claude/skills/*/SKILL.md; do
+  if ! grep -q "## PREAMBLE" "$d"; then
+    echo "MISSING: $d"
+  fi
+done
+```
+
+**Expected output:** No output (all files have the preamble).
+
+[SHELL] Spot-check banner format in 3 files:
+```bash
+grep -A 15 "## PREAMBLE" .claude/skills/dev-start/SKILL.md | head -20
+grep -A 15 "## PREAMBLE" .claude/skills/dev-status/SKILL.md | head -20
+grep -A 15 "## PREAMBLE" .claude/skills/dev-implement/SKILL.md | head -20
+```
+
+**Expected output:** Each shows the correct skill name, step count, and box-drawing `────` format.
+
+---
+
+## Deviations
+
+(none)

--- a/docs/plans/issue-9/plan.md
+++ b/docs/plans/issue-9/plan.md
@@ -1,0 +1,77 @@
+---
+issue: 9
+title: Implement skill invocation announcement banners
+branch: feature/9-skill-invocation-banners
+milestone: "v2.1 \u2014 Visibility"
+status: confirmed
+confirmed_at: 2026-04-08
+---
+
+## Overview
+
+Add a `## PREAMBLE \u2014 Announcement Banner` section to all 22 SKILL.md files, displaying a context banner as the first output of every skill invocation per SRS FR-02.
+
+## Files to Create
+
+None.
+
+## Files to Modify
+
+- `.claude/skills/dev-adr/SKILL.md` \u2014 add preamble (10 steps)
+- `.claude/skills/dev-audit/SKILL.md` \u2014 add preamble (7 steps)
+- `.claude/skills/dev-debug/SKILL.md` \u2014 add preamble (11 steps)
+- `.claude/skills/dev-deps/SKILL.md` \u2014 add preamble (8 steps)
+- `.claude/skills/dev-docs/SKILL.md` \u2014 add preamble (8 steps)
+- `.claude/skills/dev-hotfix/SKILL.md` \u2014 add preamble (12 steps)
+- `.claude/skills/dev-implement/SKILL.md` \u2014 add preamble (10 steps)
+- `.claude/skills/dev-parallel/SKILL.md` \u2014 add preamble (14 steps)
+- `.claude/skills/dev-plan/SKILL.md` \u2014 add preamble (17 steps)
+- `.claude/skills/dev-pr/SKILL.md` \u2014 add preamble (8 steps)
+- `.claude/skills/dev-release/SKILL.md` \u2014 add preamble (14 steps)
+- `.claude/skills/dev-rollback/SKILL.md` \u2014 add preamble (8 steps)
+- `.claude/skills/dev-ship/SKILL.md` \u2014 add preamble (7 steps)
+- `.claude/skills/dev-start/SKILL.md` \u2014 add preamble (8 steps)
+- `.claude/skills/dev-status/SKILL.md` \u2014 add preamble (7 steps)
+- `.claude/skills/dev-test/SKILL.md` \u2014 add preamble (11 steps)
+- `.claude/skills/dev-unblock/SKILL.md` \u2014 add preamble (8 steps)
+- `.claude/skills/next-version/SKILL.md` \u2014 add preamble (7 steps)
+- `.claude/skills/paadhai-skill/SKILL.md` \u2014 add preamble (13 steps)
+- `.claude/skills/project-init/SKILL.md` \u2014 add preamble (9 steps)
+- `.claude/skills/project-plan/SKILL.md` \u2014 add preamble (10 steps)
+- `.claude/skills/release-plan/SKILL.md` \u2014 add preamble (8 steps)
+
+## Implementation Steps
+
+1. **Define preamble template** \u2014 Two variants based on context availability:
+   - **Issue-aware variant** (skills on feature/fix branches): detect branch, extract issue number, fetch title, display full banner
+   - **Minimal variant** (skills without issue context): display skill name, step count, branch only
+
+2. **Insert preamble into all 22 SKILL.md files** \u2014 Place between skill description block and `## STEP 1`. Each gets correct step count and skill name hardcoded.
+
+3. **Verify** \u2014 Grep all SKILL.md files to confirm all 22 have the preamble section.
+
+## Test Cases
+
+- **Happy path**: Run `dev-implement` on a feature branch with an active issue \u2014 verify banner shows skill name, issue number, branch, and step count
+- **Edge case**: Run `dev-status` (read-only, no issue context) \u2014 verify banner still displays with available info (skill name only)
+- **Error case**: Run a skill with no active branch \u2014 verify banner degrades gracefully (omits branch field rather than erroring)
+
+## Security Considerations
+
+No security-relevant attack surfaces identified for this issue.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|--------------|
+| AC-1 | Preamble section added before Step 1 in all 22 skills, displays banner as first output |
+| AC-2 | Banner extracts issue number from branch name, fetches title via `gh api`; omits if not applicable |
+| AC-3 | Banner reads branch via `git branch --show-current`; omits if not on feature/fix branch |
+| AC-4 | Step count hardcoded per skill in the banner display |
+| AC-5 | Consistent `\u2500\u2500\u2500\u2500` box-drawing format across all skills, matching SRS FR-02 spec |
+
+## Definition of Done
+
+- [ ] All 22 SKILL.md files contain `## PREAMBLE \u2014 Announcement Banner`
+- [ ] Banner format matches SRS FR-02 exactly
+- [ ] All ACs checked

--- a/docs/plans/issue-9/test-plan.md
+++ b/docs/plans/issue-9/test-plan.md
@@ -1,0 +1,63 @@
+## Test Plan — Issue #9: Implement skill invocation announcement banners
+
+### Test Framework: None (markdown/shell — grep-based content verification)
+
+### Test Stub File: `tests/verify-issue-9.sh`
+
+---
+
+### Test Cases
+
+#### Happy Path
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----|-------------|-------|---------|
+| TC-01 | AC-1 | content | All 22 SKILL.md files contain `## PREAMBLE` section | `grep -rl "## PREAMBLE" .claude/skills/*/SKILL.md \| wc -l` | 22 |
+| TC-02 | AC-1 | content | No SKILL.md is missing the preamble | Loop: `grep -q "## PREAMBLE" $f` for each | 0 missing |
+| TC-03 | AC-2 | content | dev-implement (issue-aware) contains issue extraction in preamble | `preamble_grep "Extract issue number" dev-implement` | ≥1 match |
+| TC-04 | AC-2 | content | dev-start (issue-aware) contains `gh api` in preamble | `preamble_grep "gh api" dev-start` | ≥1 match |
+| TC-05 | AC-2 | content | dev-plan (issue-aware) contains `gh api` in preamble | `preamble_grep "gh api" dev-plan` | ≥1 match |
+| TC-06 | AC-3 | content | All 22 preambles detect branch via `git branch --show-current` | Loop over all skills | 22 matches |
+| TC-07 | AC-4 | content | dev-implement banner shows "10 steps" | `preamble_grep_fixed "10 steps" dev-implement` | ≥1 match |
+| TC-08 | AC-4 | content | dev-plan banner shows "17 steps" | `preamble_grep_fixed "17 steps" dev-plan` | ≥1 match |
+| TC-09 | AC-4 | content | dev-parallel banner shows "14 steps" | `preamble_grep_fixed "14 steps" dev-parallel` | ≥1 match |
+| TC-10 | AC-4 | content | dev-status banner shows "7 steps" | `preamble_grep_fixed "7 steps" dev-status` | ≥1 match |
+| TC-11 | AC-5 | content | All 22 preambles have box-drawing `────` | Loop over all skills | 22 matches |
+
+#### Edge Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----|-------------|-------|---------|
+| TC-12 | AC-2 | content | 14 issue-aware preambles reference `feature/` branch pattern | Loop over issue-aware skills | 14 matches |
+| TC-13 | AC-2 | content | 8 non-issue preambles do NOT contain `gh api` | Loop over non-issue skills | 0 matches |
+| TC-14 | AC-2 | content | 14 issue-aware preambles mention graceful degradation | Loop: `preamble_grep_case "gracefully"` | 14 matches |
+| TC-15 | AC-4 | content | Each skill's step count in banner matches expected | Compare `N steps` in preamble vs STEP_COUNTS map | All match |
+| TC-16 | AC-5 | content | PREAMBLE appears before STEP 1 in every file | Compare line numbers | true for all 22 |
+
+#### Error / Failure Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----|-------------|-------|---------|
+| TC-17 | AC-1 | content | No SKILL.md has more than one `## PREAMBLE` section | `grep -c "## PREAMBLE"` per file | exactly 1 per file |
+| TC-18 | AC-5 | content | No preamble uses plain dashes `----` instead of box-drawing `────` | Check for `^-{4,}` in preamble | 0 matches |
+| TC-19 | AC-2 | content | Non-issue skill banners don't mention "Issue #" | Loop over non-issue preambles | 0 matches |
+| TC-20 | AC-4 | content | No skill has "0 steps" in banner | Loop over all preambles | 0 matches |
+
+---
+
+### Coverage Target
+- All 5 ACs: 100% structural coverage via grep checks
+- 20 test cases: 11 happy path / 5 edge case / 4 error case
+- Behavioral coverage (manual): see below
+
+---
+
+### Manual Behavioral Test Notes
+
+These cannot be automated — they require running a Paadhai skill inside Claude Code:
+
+**M-1 (Happy path):** Run `dev-implement` on a feature branch with an active issue — verify banner shows skill name, issue number + title, branch, and step count in box-drawing format.
+
+**M-2 (Edge case):** Run `dev-status` (read-only, no issue context) — verify banner still displays with skill name, step count, and branch only (no issue line).
+
+**M-3 (Error case):** Run a skill when `gh api` fails (no network / no auth) — verify banner degrades gracefully (shows banner without issue title rather than erroring).

--- a/tests/verify-issue-9.sh
+++ b/tests/verify-issue-9.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# verify-issue-9.sh
+# Content verification for issue #9: Implement skill invocation announcement banners
+# Run from repo root: bash tests/verify-issue-9.sh
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local id="$1"
+  local description="$2"
+  local actual="$3"
+  local op="$4"
+  local expected="$5"
+
+  local ok=false
+  case "$op" in
+    ge) [ "$actual" -ge "$expected" ] 2>/dev/null && ok=true ;;
+    eq) [ "$actual" -eq "$expected" ] 2>/dev/null && ok=true ;;
+    gt) [ "$actual" -gt "$expected" ] 2>/dev/null && ok=true ;;
+  esac
+
+  if $ok; then
+    echo "  PASS [$id] $description (got $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [$id] $description (expected $op $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+grep_count() {
+  grep -c "$1" "$2" 2>/dev/null || true
+}
+
+grep_count_fixed() {
+  grep -cF "$1" "$2" 2>/dev/null || true
+}
+
+# Preamble extraction helper: get lines between ## PREAMBLE and ## STEP 1
+preamble_grep() {
+  local pattern="$1"
+  local file="$2"
+  sed -n '/^## PREAMBLE/,/^## STEP 1/p' "$file" 2>/dev/null | grep -c "$pattern" 2>/dev/null || true
+}
+
+preamble_grep_fixed() {
+  local pattern="$1"
+  local file="$2"
+  sed -n '/^## PREAMBLE/,/^## STEP 1/p' "$file" 2>/dev/null | grep -cF "$pattern" 2>/dev/null || true
+}
+
+preamble_grep_case() {
+  local pattern="$1"
+  local file="$2"
+  sed -n '/^## PREAMBLE/,/^## STEP 1/p' "$file" 2>/dev/null | grep -ci "$pattern" 2>/dev/null || true
+}
+
+# All 22 skill directories
+ALL_SKILLS=(
+  dev-adr dev-audit dev-debug dev-deps dev-docs dev-hotfix
+  dev-implement dev-parallel dev-plan dev-pr dev-release dev-rollback
+  dev-ship dev-start dev-status dev-test dev-unblock
+  next-version paadhai-skill project-init project-plan release-plan
+)
+
+# 14 issue-aware skills (Variant A)
+ISSUE_AWARE=(
+  dev-adr dev-audit dev-debug dev-docs dev-hotfix
+  dev-implement dev-parallel dev-plan dev-pr dev-rollback
+  dev-ship dev-start dev-test dev-unblock
+)
+
+# 8 non-issue skills (Variant B)
+NON_ISSUE=(
+  dev-deps dev-release dev-status next-version
+  paadhai-skill project-init project-plan release-plan
+)
+
+# Expected step counts per skill
+declare -A STEP_COUNTS=(
+  [dev-adr]=10 [dev-audit]=7 [dev-debug]=11 [dev-deps]=8
+  [dev-docs]=8 [dev-hotfix]=12 [dev-implement]=10 [dev-parallel]=14
+  [dev-plan]=17 [dev-pr]=8 [dev-release]=14 [dev-rollback]=8
+  [dev-ship]=7 [dev-start]=8 [dev-status]=7 [dev-test]=11
+  [dev-unblock]=8 [next-version]=7 [paadhai-skill]=13
+  [project-init]=9 [project-plan]=10 [release-plan]=8
+)
+
+echo ""
+echo "=== Issue #9 Content Verification ==="
+echo ""
+
+# ── Happy Path ────────────────────────────────────────────────────────────────
+echo "Happy Path"
+
+# TC-01: All 22 SKILL.md files contain ## PREAMBLE
+count=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  if grep -q "## PREAMBLE" "$f" 2>/dev/null; then
+    count=$((count + 1))
+  fi
+done
+check "TC-01" "All 22 SKILL.md files contain ## PREAMBLE" "$count" eq 22
+
+# TC-02: No SKILL.md is missing the preamble
+missing=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  if ! grep -q "## PREAMBLE" "$f" 2>/dev/null; then
+    echo "         MISSING: $f"
+    missing=$((missing + 1))
+  fi
+done
+check "TC-02" "No SKILL.md missing preamble" "$missing" eq 0
+
+# TC-03: dev-implement (issue-aware) contains issue extraction in preamble
+check "TC-03" "dev-implement: preamble has issue extraction" \
+  "$(preamble_grep 'Extract issue number' .claude/skills/dev-implement/SKILL.md)" ge 1
+
+# TC-04: dev-start (issue-aware) contains gh api in preamble
+check "TC-04" "dev-start: preamble has gh api fetch" \
+  "$(preamble_grep 'gh api' .claude/skills/dev-start/SKILL.md)" ge 1
+
+# TC-05: dev-plan (issue-aware) contains gh api in preamble
+check "TC-05" "dev-plan: preamble has gh api fetch" \
+  "$(preamble_grep 'gh api' .claude/skills/dev-plan/SKILL.md)" ge 1
+
+# TC-06: All 22 skills detect branch via git branch --show-current in preamble
+count=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep_fixed "git branch --show-current" "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    count=$((count + 1))
+  fi
+done
+check "TC-06" "All 22 preambles have git branch --show-current" "$count" eq 22
+
+# TC-07: dev-implement banner shows "10 steps"
+check "TC-07" "dev-implement: banner shows 10 steps" \
+  "$(preamble_grep_fixed '10 steps' .claude/skills/dev-implement/SKILL.md)" ge 1
+
+# TC-08: dev-plan banner shows "17 steps"
+check "TC-08" "dev-plan: banner shows 17 steps" \
+  "$(preamble_grep_fixed '17 steps' .claude/skills/dev-plan/SKILL.md)" ge 1
+
+# TC-09: dev-parallel banner shows "14 steps"
+check "TC-09" "dev-parallel: banner shows 14 steps" \
+  "$(preamble_grep_fixed '14 steps' .claude/skills/dev-parallel/SKILL.md)" ge 1
+
+# TC-10: dev-status banner shows "7 steps"
+check "TC-10" "dev-status: banner shows 7 steps" \
+  "$(preamble_grep_fixed '7 steps' .claude/skills/dev-status/SKILL.md)" ge 1
+
+# TC-11: All 22 skills have box-drawing ──── in preamble
+count=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep_fixed "────" "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    count=$((count + 1))
+  fi
+done
+check "TC-11" "All 22 preambles have box-drawing ────" "$count" eq 22
+
+echo ""
+# ── Edge Cases ────────────────────────────────────────────────────────────────
+echo "Edge Cases"
+
+# TC-12: Issue-aware skills (14) contain feature/* branch check in preamble
+count=0
+for skill in "${ISSUE_AWARE[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep_fixed "feature/" "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    count=$((count + 1))
+  fi
+done
+check "TC-12" "14 issue-aware preambles reference feature/ branch" "$count" eq 14
+
+# TC-13: Non-issue skills (8) do NOT contain gh api in preamble
+bad=0
+for skill in "${NON_ISSUE[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep 'gh api' "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    echo "         UNEXPECTED gh api in: $f"
+    bad=$((bad + 1))
+  fi
+done
+check "TC-13" "8 non-issue preambles have no gh api" "$bad" eq 0
+
+# TC-14: Issue-aware skills have graceful degradation note in preamble
+count=0
+for skill in "${ISSUE_AWARE[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep_case "gracefully" "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    count=$((count + 1))
+  fi
+done
+check "TC-14" "14 issue-aware preambles mention graceful degradation" "$count" eq 14
+
+# TC-15: Each skill's step count in banner matches expected
+mismatch=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  expected_n="${STEP_COUNTS[$skill]}"
+  c=$(preamble_grep_fixed "${expected_n} steps" "$f")
+  if [ "$c" -lt 1 ] 2>/dev/null; then
+    echo "         MISMATCH: $skill expected '${expected_n} steps' in preamble"
+    mismatch=$((mismatch + 1))
+  fi
+done
+check "TC-15" "All 22 banners have correct step count" "$mismatch" eq 0
+
+# TC-16: Preamble appears before ## STEP 1 in every file
+bad=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  preamble_line=$(grep -n "## PREAMBLE" "$f" 2>/dev/null | head -1 | cut -d: -f1)
+  step1_line=$(grep -n "## STEP 1" "$f" 2>/dev/null | head -1 | cut -d: -f1)
+  if [ -z "$preamble_line" ] || [ -z "$step1_line" ]; then
+    bad=$((bad + 1))
+  elif [ "$preamble_line" -ge "$step1_line" ] 2>/dev/null; then
+    echo "         ORDER: $skill PREAMBLE (L$preamble_line) not before STEP 1 (L$step1_line)"
+    bad=$((bad + 1))
+  fi
+done
+check "TC-16" "PREAMBLE before STEP 1 in all 22 files" "$bad" eq 0
+
+echo ""
+# ── Error / Failure Cases ─────────────────────────────────────────────────────
+echo "Error / Failure Cases"
+
+# TC-17: No SKILL.md has more than one ## PREAMBLE section
+bad=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(grep_count "## PREAMBLE" "$f")
+  if [ "$c" -gt 1 ] 2>/dev/null; then
+    echo "         DUPLICATE: $f has $c ## PREAMBLE sections"
+    bad=$((bad + 1))
+  fi
+done
+check "TC-17" "No SKILL.md has duplicate ## PREAMBLE" "$bad" eq 0
+
+# TC-18: No preamble uses plain dashes ---- instead of box-drawing ────
+bad=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  # Check for 4+ plain dashes in preamble that aren't box-drawing
+  c=$(sed -n '/^## PREAMBLE/,/^## STEP 1/p' "$f" 2>/dev/null | grep -cE "^-{4,}" 2>/dev/null || true)
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    echo "         PLAIN DASHES: $f uses ---- instead of ────"
+    bad=$((bad + 1))
+  fi
+done
+check "TC-18" "No preamble uses plain dashes instead of box-drawing" "$bad" eq 0
+
+# TC-19: Non-issue skill banners don't mention "Issue #" in preamble
+bad=0
+for skill in "${NON_ISSUE[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep_fixed "Issue #" "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    echo "         UNEXPECTED Issue # in: $f"
+    bad=$((bad + 1))
+  fi
+done
+check "TC-19" "Non-issue preambles don't mention Issue #" "$bad" eq 0
+
+# TC-20: No skill has "0 steps" in banner
+bad=0
+for skill in "${ALL_SKILLS[@]}"; do
+  f=".claude/skills/$skill/SKILL.md"
+  c=$(preamble_grep_fixed "0 steps" "$f")
+  if [ "$c" -ge 1 ] 2>/dev/null; then
+    echo "         ZERO STEPS: $f"
+    bad=$((bad + 1))
+  fi
+done
+check "TC-20" "No preamble has 0 steps" "$bad" eq 0
+
+echo ""
+echo "══════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "══════════════════════════════════════"
+echo ""
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/verify-issue-9.sh
+++ b/tests/verify-issue-9.sh
@@ -278,7 +278,7 @@ check "TC-19" "Non-issue preambles don't mention Issue #" "$bad" eq 0
 bad=0
 for skill in "${ALL_SKILLS[@]}"; do
   f=".claude/skills/$skill/SKILL.md"
-  c=$(preamble_grep_fixed "0 steps" "$f")
+  c=$(sed -n '/^## PREAMBLE/,/^## STEP 1/p' "$f" 2>/dev/null | grep -cE "^0 steps" 2>/dev/null || true)
   if [ "$c" -ge 1 ] 2>/dev/null; then
     echo "         ZERO STEPS: $f"
     bad=$((bad + 1))


### PR DESCRIPTION
## Summary
- Add `## PREAMBLE — Announcement Banner` section to all 22 SKILL.md files
- Issue-aware skills (14) detect branch, extract issue number, fetch title via `gh api`, with graceful degradation
- Non-issue skills (8) display skill name, step count, and branch only
- Consistent box-drawing (`────`) banner format across all skills per SRS FR-02
- Content verification script (`tests/verify-issue-9.sh`) with 20 test cases — all passing

## Changes
- `.claude/skills/dev-adr/SKILL.md` — add issue-aware preamble (10 steps)
- `.claude/skills/dev-audit/SKILL.md` — add issue-aware preamble (7 steps)
- `.claude/skills/dev-debug/SKILL.md` — add issue-aware preamble (11 steps)
- `.claude/skills/dev-deps/SKILL.md` — add non-issue preamble (8 steps)
- `.claude/skills/dev-docs/SKILL.md` — add issue-aware preamble (8 steps)
- `.claude/skills/dev-hotfix/SKILL.md` — add issue-aware preamble (12 steps)
- `.claude/skills/dev-implement/SKILL.md` — add issue-aware preamble (10 steps)
- `.claude/skills/dev-parallel/SKILL.md` — add issue-aware preamble (14 steps)
- `.claude/skills/dev-plan/SKILL.md` — add issue-aware preamble (17 steps)
- `.claude/skills/dev-pr/SKILL.md` — add issue-aware preamble (8 steps)
- `.claude/skills/dev-release/SKILL.md` — add non-issue preamble (14 steps)
- `.claude/skills/dev-rollback/SKILL.md` — add issue-aware preamble (8 steps)
- `.claude/skills/dev-ship/SKILL.md` — add issue-aware preamble (7 steps)
- `.claude/skills/dev-start/SKILL.md` — add issue-aware preamble (8 steps)
- `.claude/skills/dev-status/SKILL.md` — add non-issue preamble (7 steps)
- `.claude/skills/dev-test/SKILL.md` — add issue-aware preamble (11 steps)
- `.claude/skills/dev-unblock/SKILL.md` — add issue-aware preamble (8 steps)
- `.claude/skills/next-version/SKILL.md` — add non-issue preamble (7 steps)
- `.claude/skills/paadhai-skill/SKILL.md` — add non-issue preamble (13 steps)
- `.claude/skills/project-init/SKILL.md` — add non-issue preamble (9 steps)
- `.claude/skills/project-plan/SKILL.md` — add non-issue preamble (10 steps)
- `.claude/skills/release-plan/SKILL.md` — add non-issue preamble (8 steps)
- `docs/plans/issue-9/plan.md` — confirmed plan
- `docs/plans/issue-9/implementation.md` — implementation doc (all steps done)
- `docs/plans/issue-9/test-plan.md` — test plan (20 cases)
- `tests/verify-issue-9.sh` — content verification script

## Test Plan
- [ ] `bash tests/verify-issue-9.sh` — 20/20 tests pass
- [ ] TC-01: All 22 SKILL.md files contain `## PREAMBLE`
- [ ] TC-06: All 22 preambles have `git branch --show-current`
- [ ] TC-11: All 22 preambles have box-drawing `────`
- [ ] TC-12: 14 issue-aware preambles reference `feature/` branch
- [ ] TC-13: 8 non-issue preambles have no `gh api`
- [ ] TC-15: All 22 banners have correct step count

## Acceptance Criteria
- [x] AC-1: Every skill displays a context banner as its first output upon invocation
- [x] AC-2: Banner includes the skill name and issue number (if applicable)
- [x] AC-3: Banner includes current branch name (if on a feature/fix branch)
- [x] AC-4: For multi-step skills, the banner includes the total step count
- [x] AC-5: Banner uses a consistent visual format (box-drawing characters) across all skills

## Notes
- Two preamble variants: issue-aware (14 skills) and non-issue (8 skills)
- Issue-aware variant extracts issue number from branch name and fetches title via `gh api`, with graceful degradation if API call fails
- Non-issue variant shows skill name, step count, and branch only
- Refs: SRS FR-02

Closes #9