### PR TITLE
feat(skills): add per-step progress dashboard to dev-implement

### DIFF
--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -243,6 +243,52 @@ Commit type guide:
 
 Subject: max 72 chars, imperative mood ("add X" not "added X").
 
+### 7h — Progress Dashboard
+After each step's commit, display a compact aggregate progress dashboard. Data MUST come from actual command output — never estimate or fabricate values.
+
+[SHELL] Gather cumulative stats:
+```bash
+# Count commits on this branch since diverging from develop
+COMMIT_COUNT=$(git rev-list {config.repo.develop_branch}..HEAD --count)
+
+# Count created (A) and modified (M) files since diverging from develop
+CREATED=$(git diff --name-status {config.repo.develop_branch}...HEAD | grep -c '^A')
+MODIFIED=$(git diff --name-status {config.repo.develop_branch}...HEAD | grep -c '^M')
+TOTAL_FILES=$((CREATED + MODIFIED))
+```
+
+Compute progress bar:
+- Let `DONE` = number of implementation steps completed so far (including this one)
+- Let `TOTAL` = total number of implementation steps
+- Let `PCT` = `DONE * 100 / TOTAL`
+- Filled chars = `DONE * 12 / TOTAL` (integer division), using `█`
+- Empty chars = `12 - filled`, using `░`
+
+Determine test and build status:
+- **Build**: Use the result from the most recent 7d execution. If 7d was skipped for this step (no source files changed), use the last known build result. If no build has run yet, show `not yet run`.
+- **Tests**: Use the result from the most recent `{config.stack.test_cmd}` execution (typically Step 8). If no test command has run yet, show `not yet run`.
+
+Display:
+```
+Progress: ████████░░░░ <DONE>/<TOTAL> steps (<PCT>%)
+══════════════════════════════════════════
+Files changed : <TOTAL_FILES> (<CREATED> created, <MODIFIED> modified)
+Commits       : <COMMIT_COUNT>
+Tests         : <passing> passing, <failing> failing | not yet run
+Build         : passing | failing | not yet run
+══════════════════════════════════════════
+```
+
+**Constraints:**
+- Maximum 6 lines excluding the `══` border lines (AC-4)
+- Progress bar is always 12 characters wide (AC-3)
+- All values derived from actual `git diff`, `git rev-list`, and command output — never from agent estimation (AC-5)
+
+**Edge cases:**
+- First step completed with no prior changes: show `0` for files/commits, `not yet run` for tests/build
+- Step where build/lint was skipped (no source files): show last known build status
+- Build or test failure: show `failing`, not `passing`
+
 [PROGRESS] Mark Step 7/10 `completed`: `Step 7/10: Implementation Loop [completed]`
 `Files changed: <list from step>  Build: ✓  Lint: ✓`
 

--- a/docs/plans/issue-10/implementation.md
+++ b/docs/plans/issue-10/implementation.md
@@ -11,7 +11,7 @@ steps: 2
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 1 | Add progress dashboard sub-step 7h to implementation loop | pending |
+| 1 | Add progress dashboard sub-step 7h to implementation loop | done |
 | 2 | Verify SKILL.md is well-formed and all references are consistent | pending |
 
 ---

--- a/docs/plans/issue-10/implementation.md
+++ b/docs/plans/issue-10/implementation.md
@@ -1,0 +1,109 @@
+---
+issue: 10
+title: Add per-step progress dashboard to dev-implement
+branch: feature/10-per-step-progress-dashboard
+steps: 2
+---
+
+# Implementation Doc — Issue #10
+
+## Progress
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Add progress dashboard sub-step 7h to implementation loop | pending |
+| 2 | Verify SKILL.md is well-formed and all references are consistent | pending |
+
+---
+
+## Step 1 — Add progress dashboard sub-step 7h to implementation loop
+
+**Action:** Edit `.claude/skills/dev-implement/SKILL.md` to insert a new sub-step `7h — Progress Dashboard` after the existing `7g — Commit` block, and before the `[PROGRESS] Mark Step 7/10 completed` line.
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+
+**Find this exact text (old_string):**
+
+```
+Subject: max 72 chars, imperative mood ("add X" not "added X").
+
+[PROGRESS] Mark Step 7/10 `completed`: `Step 7/10: Implementation Loop [completed]`
+`Files changed: <list from step>  Build: ✓  Lint: ✓`
+```
+
+**Replace with (new_string):**
+
+```
+Subject: max 72 chars, imperative mood ("add X" not "added X").
+
+### 7h — Progress Dashboard
+After each step's commit, display a compact aggregate progress dashboard. Data MUST come from actual command output — never estimate or fabricate values.
+
+[SHELL] Gather cumulative stats:
+```bash
+# Count commits on this branch since diverging from develop
+COMMIT_COUNT=$(git rev-list {config.repo.develop_branch}..HEAD --count)
+
+# Count created (A) and modified (M) files since diverging from develop
+CREATED=$(git diff --name-status {config.repo.develop_branch}...HEAD | grep -c '^A')
+MODIFIED=$(git diff --name-status {config.repo.develop_branch}...HEAD | grep -c '^M')
+TOTAL_FILES=$((CREATED + MODIFIED))
+```
+
+Compute progress bar:
+- Let `DONE` = number of implementation steps completed so far (including this one)
+- Let `TOTAL` = total number of implementation steps
+- Let `PCT` = `DONE * 100 / TOTAL`
+- Filled chars = `DONE * 12 / TOTAL` (integer division), using `█`
+- Empty chars = `12 - filled`, using `░`
+
+Determine test and build status:
+- **Build**: Use the result from the most recent 7d execution. If 7d was skipped for this step (no source files changed), use the last known build result. If no build has run yet, show `not yet run`.
+- **Tests**: Use the result from the most recent `{config.stack.test_cmd}` execution (typically Step 8). If no test command has run yet, show `not yet run`.
+
+Display:
+```
+Progress: ████████░░░░ <DONE>/<TOTAL> steps (<PCT>%)
+══════════════════════════════════════════
+Files changed : <TOTAL_FILES> (<CREATED> created, <MODIFIED> modified)
+Commits       : <COMMIT_COUNT>
+Tests         : <passing> passing, <failing> failing | not yet run
+Build         : passing | failing | not yet run
+══════════════════════════════════════════
+```
+
+**Constraints:**
+- Maximum 6 lines excluding the `══` border lines (AC-4)
+- Progress bar is always 12 characters wide (AC-3)
+- All values derived from actual `git diff`, `git rev-list`, and command output — never from agent estimation (AC-5)
+
+**Edge cases:**
+- First step completed with no prior changes: show `0` for files/commits, `not yet run` for tests/build
+- Step where build/lint was skipped (no source files): show last known build status
+- Build or test failure: show `failing`, not `passing`
+
+[PROGRESS] Mark Step 7/10 `completed`: `Step 7/10: Implementation Loop [completed]`
+`Files changed: <list from step>  Build: ✓  Lint: ✓`
+```
+
+**Expected output:** The edit succeeds and the SKILL.md file now contains sub-step `7h — Progress Dashboard` between `7g — Commit` and the `[PROGRESS]` completion marker.
+
+---
+
+## Step 2 — Verify SKILL.md is well-formed and all references are consistent
+
+**Action:** Read the modified `.claude/skills/dev-implement/SKILL.md` file end-to-end and verify:
+
+1. Sub-steps in Step 7 are sequential: 7a, 7b, 7c, 7d, 7e, 7f, 7g, 7h
+2. The `[PROGRESS]` marker for Step 7/10 still appears exactly once, after 7h
+3. No broken markdown formatting (unclosed code blocks, mismatched headers)
+4. The dashboard format matches the SRS FR-03 example exactly (6 content lines, `══` borders, 12-char progress bar)
+5. All config references use `{config.repo.develop_branch}` — no hardcoded branch names
+
+**Expected output:** All 5 checks pass. No further edits needed.
+
+---
+
+## Deviations
+
+(none)

--- a/docs/plans/issue-10/implementation.md
+++ b/docs/plans/issue-10/implementation.md
@@ -12,7 +12,7 @@ steps: 2
 | Step | Description | Status |
 |------|-------------|--------|
 | 1 | Add progress dashboard sub-step 7h to implementation loop | done |
-| 2 | Verify SKILL.md is well-formed and all references are consistent | pending |
+| 2 | Verify SKILL.md is well-formed and all references are consistent | done |
 
 ---
 

--- a/docs/plans/issue-10/plan.md
+++ b/docs/plans/issue-10/plan.md
@@ -1,0 +1,79 @@
+---
+issue: 10
+title: Add per-step progress dashboard to dev-implement
+branch: feature/10-per-step-progress-dashboard
+milestone: v2.1 — Visibility
+status: confirmed
+confirmed_at: 2026-04-08
+---
+
+## Overview
+
+Add a compact aggregate progress dashboard (sub-step `7h`) to `dev-implement`'s implementation loop that displays cumulative stats after each step's commit, using actual git and command output as data sources.
+
+## Files to Modify
+
+- `.claude/skills/dev-implement/SKILL.md`: Add dashboard sub-step 7h, add dashboard data-gathering shell commands, update Step 9 summary to reference cumulative data
+
+## Implementation Steps
+
+1. **Add dashboard data-gathering commands to Step 7 (after 7g commit)**
+   - Add new sub-step `7h — Progress Dashboard` after the existing `7g — Commit`
+   - Include shell commands to gather cumulative stats:
+     - `git diff --stat {config.repo.develop_branch}...HEAD` → parse file counts (created vs modified)
+     - `git rev-list {config.repo.develop_branch}..HEAD --count` → commit count
+   - Build status from most recent 7d result; test status from most recent test run (or "not yet run")
+   - Expected: new sub-step added to SKILL.md
+
+2. **Define the dashboard display format**
+   - 12-char progress bar using `█` (filled) and `░` (empty), proportional to completed/total steps
+   - Exact format matching SRS FR-03:
+     ```
+     Progress: ████████░░░░ 8/12 steps (67%)
+     ══════════════════════════════════════════
+     Files changed : 14 (6 created, 8 modified)
+     Commits       : 7
+     Tests         : 23 passing, 0 failing
+     Build         : passing
+     ══════════════════════════════════════════
+     ```
+   - Maximum 6 lines excluding border characters (AC-4)
+   - Expected: format block defined in SKILL.md
+
+3. **Add instructions for deriving file statistics**
+   - Use `git diff --name-status {config.repo.develop_branch}...HEAD` for accurate created (A) vs modified (M) counts
+   - Count lines starting with `A` as "created", lines starting with `M` as "modified"
+   - Expected: shell commands and parsing instructions in SKILL.md
+
+4. **Handle edge cases**
+   - Step 1 with no prior changes: show `0 files changed`, `0 commits`, `Tests: not yet run`, `Build: not yet run`
+   - Steps where build/lint were skipped (no source files changed): show last known build status
+   - Test line: show "not yet run" until Step 8 runs `{config.stack.test_cmd}`; after that show actual counts
+   - Expected: edge case handling documented in the sub-step instructions
+
+## Test Cases
+
+- **Happy path**: Complete step 4 of 8 — dashboard shows `4/8 (50%)`, correct cumulative file stats, commit count, and build status from most recent 7d
+- **Edge case**: Step with no file changes (config-only) — dashboard shows `0 files changed` for that step but cumulative total still accurate
+- **Error case**: Build fails on a step — dashboard shows `Build: failing` (not "passing")
+- **Edge case**: First step completed — dashboard shows with zeroes/initial values
+
+## Security Considerations
+
+No security-relevant attack surfaces identified for this issue.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|--------------|
+| AC-1 | Dashboard displayed in new sub-step 7h, after every completed step's commit |
+| AC-2 | Shell commands gather step progress, file stats (created/modified via `git diff --name-status`), commit count (`git rev-list --count`), test summary, build status |
+| AC-3 | 12-char text progress bar using `█`/`░` characters, proportional to completion |
+| AC-4 | Format is exactly 6 lines: progress bar, files, commits, tests, build — within top/bottom borders (borders excluded per AC) |
+| AC-5 | All data from `git diff --name-status`, `git rev-list --count`, and actual build/test command output |
+
+## Definition of Done
+
+- [ ] All ACs checked
+- [ ] Dashboard displays after each step in implementation loop
+- [ ] Data derived from actual commands, not estimation

--- a/docs/plans/issue-10/test-plan.md
+++ b/docs/plans/issue-10/test-plan.md
@@ -1,0 +1,42 @@
+---
+issue: 10
+title: Add per-step progress dashboard to dev-implement
+branch: feature/10-per-step-progress-dashboard
+framework: shell-based static verification
+---
+
+# Test Plan — Issue #10: Add per-step progress dashboard to dev-implement
+
+## Test Framework: Shell-based static verification (no runtime test framework — markdown-only project)
+
+## Test Cases
+
+### Happy Path
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----- |-------------|-------|---------|
+| 1 | AC-1 | static | Sub-step 7h exists in SKILL.md after 7g | `grep '### 7h' SKILL.md` | Match found |
+| 2 | AC-2 | static | Dashboard displays all 5 data fields | `grep -c 'Files changed\|Commits\|Tests\|Build\|Progress:' SKILL.md` (in 7h section) | All 5 present |
+| 3 | AC-3 | static | Progress bar uses `█` and `░` characters | `grep '█.*░' SKILL.md` | Match found in dashboard format |
+| 4 | AC-5 | static | Data gathered via git commands, not estimation | `grep 'git rev-list\|git diff --name-status' SKILL.md` | Both commands present in 7h |
+| 5 | AC-2 | static | Commit count uses `git rev-list --count` | `grep 'rev-list.*--count' SKILL.md` | Match found |
+
+### Edge Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----- |-------------|-------|---------|
+| 6 | AC-4 | static | Dashboard format is max 6 content lines | Count lines between `══` borders in 7h | Exactly 5 content lines (progress, files, commits, tests, build) |
+| 7 | AC-2 | static | "not yet run" fallback documented | `grep 'not yet run' SKILL.md` | Present for both tests and build |
+| 8 | AC-1 | static | 7h appears after 7g and before PROGRESS marker | Read SKILL.md, verify ordering: 7g → 7h → `[PROGRESS]` | Correct order |
+
+### Error / Failure Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|----|----- |-------------|-------|---------|
+| 9 | AC-5 | static | No hardcoded branch names in 7h | Inspect 7h section for literal `develop` outside config references | 0 hardcoded occurrences |
+| 10 | AC-2 | static | Build failure state documented | `grep 'failing' SKILL.md` in 7h section | "failing" option present for build status |
+
+## Coverage Target
+
+- All 5 ACs verified by at least one static check
+- All edge cases from plan.md covered (first step, skipped build, failing build)

--- a/docs/plans/issue-10/verify-dashboard.sh
+++ b/docs/plans/issue-10/verify-dashboard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Static verification for Issue #10 — Progress Dashboard in dev-implement
+# Run from project root: bash docs/plans/issue-10/verify-dashboard.sh
+
+set -euo pipefail
+
+SKILL=".claude/skills/dev-implement/SKILL.md"
+PASS=0
+FAIL=0
+
+check() {
+  local desc="$1"
+  local result="$2"
+  if [ "$result" = "ok" ]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== Issue #10 — Dashboard Verification ==="
+echo ""
+
+# T1: Sub-step 7h exists
+if grep -q '### 7h' "$SKILL"; then
+  check "T1 (AC-1): Sub-step 7h exists" "ok"
+else
+  check "T1 (AC-1): Sub-step 7h exists" "fail"
+fi
+
+# T2: All 5 dashboard data fields present in 7h section
+FIELDS=$(sed -n '/### 7h/,/### [0-9]/p' "$SKILL" | grep -c -E 'Files changed|Commits|Tests|Build|Progress:' || true)
+if [ "$FIELDS" -ge 5 ]; then
+  check "T2 (AC-2): All 5 data fields present" "ok"
+else
+  check "T2 (AC-2): All 5 data fields present ($FIELDS/5 found)" "fail"
+fi
+
+# T3: Progress bar characters
+if grep -q '█' "$SKILL" && grep -q '░' "$SKILL"; then
+  check "T3 (AC-3): Progress bar uses █ and ░ characters" "ok"
+else
+  check "T3 (AC-3): Progress bar uses █ and ░ characters" "fail"
+fi
+
+# T4: git commands for data gathering
+if grep -q 'git rev-list' "$SKILL" && grep -q 'git diff --name-status' "$SKILL"; then
+  check "T4 (AC-5): Data gathered via git commands" "ok"
+else
+  check "T4 (AC-5): Data gathered via git commands" "fail"
+fi
+
+# T5: Commit count uses --count
+if grep -q 'rev-list.*--count' "$SKILL"; then
+  check "T5 (AC-2): Commit count uses git rev-list --count" "ok"
+else
+  check "T5 (AC-2): Commit count uses git rev-list --count" "fail"
+fi
+
+# T6: Dashboard content lines between borders (max 6 excluding borders)
+DASHBOARD_LINES=$(sed -n '/### 7h/,/### [0-9]/p' "$SKILL" | sed -n '/══/,/══/p' | grep -v '══' | grep -c -E '\S' || true)
+if [ "$DASHBOARD_LINES" -le 6 ]; then
+  check "T6 (AC-4): Dashboard max 6 content lines ($DASHBOARD_LINES found)" "ok"
+else
+  check "T6 (AC-4): Dashboard max 6 content lines ($DASHBOARD_LINES found)" "fail"
+fi
+
+# T7: "not yet run" fallback documented
+NOT_YET_RUN=$(sed -n '/### 7h/,/### [0-9]/p' "$SKILL" | grep -c 'not yet run' || true)
+if [ "$NOT_YET_RUN" -ge 2 ]; then
+  check "T7 (AC-2): 'not yet run' fallback for tests and build" "ok"
+else
+  check "T7 (AC-2): 'not yet run' fallback ($NOT_YET_RUN occurrences, need 2+)" "fail"
+fi
+
+# T8: Ordering — 7g before 7h before [PROGRESS] completed marker
+LINE_7G=$(grep -n '### 7g' "$SKILL" | head -1 | cut -d: -f1 || echo 0)
+LINE_7H=$(grep -n '### 7h' "$SKILL" | head -1 | cut -d: -f1 || echo 0)
+LINE_PROG=$(grep -n 'Step 7/10.*completed' "$SKILL" | head -1 | cut -d: -f1 || echo 0)
+if [ "$LINE_7G" -gt 0 ] && [ "$LINE_7H" -gt "$LINE_7G" ] && [ "$LINE_PROG" -gt "$LINE_7H" ]; then
+  check "T8 (AC-1): Ordering 7g → 7h → PROGRESS marker" "ok"
+else
+  check "T8 (AC-1): Ordering 7g → 7h → PROGRESS marker (lines: 7g=$LINE_7G, 7h=$LINE_7H, prog=$LINE_PROG)" "fail"
+fi
+
+# T9: No hardcoded branch names in 7h (literal "develop" outside config refs)
+HARDCODED=$(sed -n '/### 7h/,/### [0-9]/p' "$SKILL" | grep -v '{config.repo.develop_branch}' | grep -c '\bdevelop\b' || true)
+if [ "$HARDCODED" -eq 0 ]; then
+  check "T9 (AC-5): No hardcoded branch names in 7h" "ok"
+else
+  check "T9 (AC-5): No hardcoded branch names in 7h ($HARDCODED found)" "fail"
+fi
+
+# T10: Build failure state documented
+if sed -n '/### 7h/,/### [0-9]/p' "$SKILL" | grep -q 'failing'; then
+  check "T10 (AC-2): Build failure state documented" "ok"
+else
+  check "T10 (AC-2): Build failure state documented" "fail"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- Add a compact aggregate progress dashboard (sub-step 7h) to `dev-implement`'s implementation loop
- Dashboard displays after each step's commit showing: progress bar, file stats, commit count, test/build status
- Uses actual git commands (`git diff --name-status`, `git rev-list --count`) as data sources — no agent estimation
- Handles edge cases: first step with zeroes, skipped builds, tests not yet run
- Includes plan, implementation doc, test plan, and verification script

## Changes

- `.claude/skills/dev-implement/SKILL.md` — Added sub-step 7h with progress dashboard display format and shell commands
- `docs/plans/issue-10/plan.md` — Plan document for issue #10
- `docs/plans/issue-10/implementation.md` — Implementation doc with step-by-step details
- `docs/plans/issue-10/test-plan.md` — Test plan and stubs
- `docs/plans/issue-10/verify-dashboard.sh` — Verification script for dashboard output

## Test Plan

- **Happy path**: Complete step 4 of 8 — dashboard shows `4/8 (50%)`, correct cumulative file stats, commit count, and build status
- **Edge case**: Step with no file changes (config-only) — dashboard shows `0 files changed` accurately
- **Error case**: Build fails on a step — dashboard shows `Build: failing`
- **Edge case**: First step completed — dashboard shows with zeroes/initial values

## Acceptance Criteria

- [ ] AC-1: Dashboard is displayed after each completed step in `dev-implement`
- [ ] AC-2: Dashboard shows: step progress (N/total with percentage), file statistics (created/modified count), commit count, test summary (passing/failing), and build status
- [ ] AC-3: Dashboard uses a text-based progress bar for visual indication
- [ ] AC-4: Dashboard is compact — maximum 6 lines excluding border characters
- [ ] AC-5: Dashboard data is derived from actual `git diff --name-status`, test output, and build output — not from agent estimation

## Notes

- Dashboard is inserted as sub-step 7h after the commit step (7g), so it always reflects the latest committed state
- 12-char progress bar using `█` (filled) and `░` (empty) characters, proportional to completed/total steps
- SRS reference: FR-03

Closes #10