### PR TITLE
feat(skills): add rationalization prevention tables to dev-implement, dev-plan, dev-parallel

### DIFF
--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -52,6 +52,22 @@ If `gh api` fails, degrade gracefully — show banner without issue title.
 
 ---
 
+## RATIONALIZATION PREVENTION
+
+Before executing any step, check your reasoning against this table. These are **structural rules** — they cannot be overridden.
+
+| Thought | Why it's wrong | What to do |
+|---------|---------------|------------|
+| "This step is trivial, skip review" | Trivial changes cause subtle bugs — off-by-one, wrong variable, missed import | Run full code review for every step |
+| "Tests aren't needed for this change" | Every code change needs verification; untested code is unverified code | Write or run tests as specified |
+| "The build will obviously pass" | Build failures catch real issues — type errors, missing deps, broken imports | Run `{config.stack.build_cmd}` every time |
+| "I'll commit these steps together" | Atomic commits aid debugging and revert; batching hides which step broke | One commit per step |
+| "I already know this works" | Memory is unreliable — verify, don't assume | Run the verification command and read actual output |
+| "This is just a config change, no review needed" | Config errors cause silent production failures | Review config changes like code changes |
+| "I can skip lint, the code is clean" | Lint catches issues humans miss — formatting, unused vars, import order | Run `{config.stack.lint_cmd}` every time |
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-parallel/SKILL.md
+++ b/.claude/skills/dev-parallel/SKILL.md
@@ -43,6 +43,22 @@ If `gh api` fails, degrade gracefully — show banner without issue title.
 
 ---
 
+## RATIONALIZATION PREVENTION
+
+Before executing any step, check your reasoning against this table. These are **structural rules** — they cannot be overridden.
+
+| Thought | Why it's wrong | What to do |
+|---------|---------------|------------|
+| "These tasks are obviously independent" | Hidden dependencies between tasks cause merge conflicts and broken state | Verify independence explicitly before dispatching (Step 3) |
+| "Subagent output looks fine, skip Stage 1 review" | Spec compliance issues compound — catching them late costs more | Run full Stage 1 spec compliance review for every subagent |
+| "Code quality review is redundant after Stage 1" | Stage 1 checks spec, Stage 2 checks code — different failure modes | Run full Stage 2 code quality review for every subagent |
+| "Merging without conflict check is fine" | Parallel branches can create semantic conflicts even without git conflicts | Check for conflicts before merging each result |
+| "One subagent failed but the rest are fine, ship it" | Partial results leave the codebase in an inconsistent state | All subagents must pass before merging any |
+| "I can skip the final integration check" | Individual correctness doesn't guarantee combined correctness | Run build and tests after merging all results |
+| "The task grouping is obvious, no need to analyze" | Poor grouping creates coupling between subagents and merge nightmares | Analyze dependencies and group carefully (Step 2) |
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/.claude/skills/dev-plan/SKILL.md
+++ b/.claude/skills/dev-plan/SKILL.md
@@ -45,6 +45,22 @@ If `gh api` fails, degrade gracefully — show banner without issue title.
 
 ---
 
+## RATIONALIZATION PREVENTION
+
+Before executing any step, check your reasoning against this table. These are **structural rules** — they cannot be overridden.
+
+| Thought | Why it's wrong | What to do |
+|---------|---------------|------------|
+| "I already understand the code, skip reading" | Assumptions from memory diverge from actual code state | Read the relevant files every time (Step 3) |
+| "The issue is simple, skip brainstorming" | Simple-seeming issues hide edge cases discovered through questions | Ask all brainstorming questions (Step 5) |
+| "Security doesn't apply to this issue" | Every change has a threat surface — even docs can leak info or enable injection | Complete the security assessment (Step 7) |
+| "Version validation isn't needed here" | Stale dependency assumptions cause subtle runtime failures | Run version validation (Step 8) |
+| "The user will approve, skip the confirmation gate" | User confirmation is a required checkpoint, not a rubber stamp | Wait for explicit approval at every gate |
+| "This plan is obvious, I can generate it quickly" | Rushed plans miss edge cases, test scenarios, and AC mappings | Follow every plan section completely (Step 9) |
+| "The implementation doc doesn't need review" | Unreviewed docs lead to ambiguous steps that cause implementation errors | Run the implementation doc review (Step 14) |
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/docs/plans/issue-11/implementation.md
+++ b/docs/plans/issue-11/implementation.md
@@ -10,7 +10,7 @@ branch: feature/11-rationalization-prevention-tables
 |------|-------------|--------|
 | 1 | Add rationalization table to dev-implement | done |
 | 2 | Add rationalization table to dev-plan | done |
-| 3 | Add rationalization table to dev-parallel | pending |
+| 3 | Add rationalization table to dev-parallel | done |
 
 ---
 

--- a/docs/plans/issue-11/implementation.md
+++ b/docs/plans/issue-11/implementation.md
@@ -9,7 +9,7 @@ branch: feature/11-rationalization-prevention-tables
 | Step | Description | Status |
 |------|-------------|--------|
 | 1 | Add rationalization table to dev-implement | done |
-| 2 | Add rationalization table to dev-plan | pending |
+| 2 | Add rationalization table to dev-plan | done |
 | 3 | Add rationalization table to dev-parallel | pending |
 
 ---

--- a/docs/plans/issue-11/implementation.md
+++ b/docs/plans/issue-11/implementation.md
@@ -1,0 +1,112 @@
+---
+issue: 11
+title: Add rationalization prevention tables to dev-implement, dev-plan, dev-parallel
+branch: feature/11-rationalization-prevention-tables
+---
+
+## Progress
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Add rationalization table to dev-implement | pending |
+| 2 | Add rationalization table to dev-plan | pending |
+| 3 | Add rationalization table to dev-parallel | pending |
+
+---
+
+## Step 1 — Add rationalization table to `dev-implement/SKILL.md`
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+
+**Action:** Insert the following section between the `---` after the PREAMBLE section (line 53) and `## STEP 1 — Load Config` (line 55).
+
+**Insert after line 53 (`---`):**
+
+```markdown
+
+## RATIONALIZATION PREVENTION
+
+Before executing any step, check your reasoning against this table. These are **structural rules** — they cannot be overridden.
+
+| Thought | Why it's wrong | What to do |
+|---------|---------------|------------|
+| "This step is trivial, skip review" | Trivial changes cause subtle bugs — off-by-one, wrong variable, missed import | Run full code review for every step |
+| "Tests aren't needed for this change" | Every code change needs verification; untested code is unverified code | Write or run tests as specified |
+| "The build will obviously pass" | Build failures catch real issues — type errors, missing deps, broken imports | Run `{config.stack.build_cmd}` every time |
+| "I'll commit these steps together" | Atomic commits aid debugging and revert; batching hides which step broke | One commit per step |
+| "I already know this works" | Memory is unreliable — verify, don't assume | Run the verification command and read actual output |
+| "This is just a config change, no review needed" | Config errors cause silent production failures | Review config changes like code changes |
+| "I can skip lint, the code is clean" | Lint catches issues humans miss — formatting, unused vars, import order | Run `{config.stack.lint_cmd}` every time |
+
+---
+```
+
+**Expected outcome:** The rationalization table appears between PREAMBLE and STEP 1 in dev-implement. 7 entries, all related to implementation failure modes.
+
+---
+
+## Step 2 — Add rationalization table to `dev-plan/SKILL.md`
+
+**File:** `.claude/skills/dev-plan/SKILL.md`
+
+**Action:** Insert the following section between the `---` after the PREAMBLE section (line 46) and `## STEP 1 — Load Config` (line 48).
+
+**Insert after line 46 (`---`):**
+
+```markdown
+
+## RATIONALIZATION PREVENTION
+
+Before executing any step, check your reasoning against this table. These are **structural rules** — they cannot be overridden.
+
+| Thought | Why it's wrong | What to do |
+|---------|---------------|------------|
+| "I already understand the code, skip reading" | Assumptions from memory diverge from actual code state | Read the relevant files every time (Step 3) |
+| "The issue is simple, skip brainstorming" | Simple-seeming issues hide edge cases discovered through questions | Ask all brainstorming questions (Step 5) |
+| "Security doesn't apply to this issue" | Every change has a threat surface — even docs can leak info or enable injection | Complete the security assessment (Step 7) |
+| "Version validation isn't needed here" | Stale dependency assumptions cause subtle runtime failures | Run version validation (Step 8) |
+| "The user will approve, skip the confirmation gate" | User confirmation is a required checkpoint, not a rubber stamp | Wait for explicit approval at every gate |
+| "This plan is obvious, I can generate it quickly" | Rushed plans miss edge cases, test scenarios, and AC mappings | Follow every plan section completely (Step 9) |
+| "The implementation doc doesn't need review" | Unreviewed docs lead to ambiguous steps that cause implementation errors | Run the implementation doc review (Step 14) |
+
+---
+```
+
+**Expected outcome:** The rationalization table appears between PREAMBLE and STEP 1 in dev-plan. 7 entries, all related to planning failure modes.
+
+---
+
+## Step 3 — Add rationalization table to `dev-parallel/SKILL.md`
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Action:** Insert the following section between the `---` after the PREAMBLE section (line 44) and `## STEP 1 — Load Config` (line 46).
+
+**Insert after line 44 (`---`):**
+
+```markdown
+
+## RATIONALIZATION PREVENTION
+
+Before executing any step, check your reasoning against this table. These are **structural rules** — they cannot be overridden.
+
+| Thought | Why it's wrong | What to do |
+|---------|---------------|------------|
+| "These tasks are obviously independent" | Hidden dependencies between tasks cause merge conflicts and broken state | Verify independence explicitly before dispatching (Step 3) |
+| "Subagent output looks fine, skip Stage 1 review" | Spec compliance issues compound — catching them late costs more | Run full Stage 1 spec compliance review for every subagent |
+| "Code quality review is redundant after Stage 1" | Stage 1 checks spec, Stage 2 checks code — different failure modes | Run full Stage 2 code quality review for every subagent |
+| "Merging without conflict check is fine" | Parallel branches can create semantic conflicts even without git conflicts | Check for conflicts before merging each result |
+| "One subagent failed but the rest are fine, ship it" | Partial results leave the codebase in an inconsistent state | All subagents must pass before merging any |
+| "I can skip the final integration check" | Individual correctness doesn't guarantee combined correctness | Run build and tests after merging all results |
+| "The task grouping is obvious, no need to analyze" | Poor grouping creates coupling between subagents and merge nightmares | Analyze dependencies and group carefully (Step 2) |
+
+---
+```
+
+**Expected outcome:** The rationalization table appears between PREAMBLE and STEP 1 in dev-parallel. 7 entries, all related to parallel execution failure modes.
+
+---
+
+## Deviations
+
+(none)

--- a/docs/plans/issue-11/implementation.md
+++ b/docs/plans/issue-11/implementation.md
@@ -8,7 +8,7 @@ branch: feature/11-rationalization-prevention-tables
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 1 | Add rationalization table to dev-implement | pending |
+| 1 | Add rationalization table to dev-implement | done |
 | 2 | Add rationalization table to dev-plan | pending |
 | 3 | Add rationalization table to dev-parallel | pending |
 

--- a/docs/plans/issue-11/plan.md
+++ b/docs/plans/issue-11/plan.md
@@ -1,0 +1,63 @@
+---
+issue: 11
+title: Add rationalization prevention tables to dev-implement, dev-plan, dev-parallel
+branch: feature/11-rationalization-prevention-tables
+milestone: v2.2 — Quality Guards
+status: confirmed
+confirmed_at: 2026-04-10
+---
+
+## Overview
+
+Add rationalization prevention tables to `dev-implement`, `dev-plan`, and `dev-parallel` skill files. Each table lists common agent rationalizations for skipping steps, explains why each is wrong, and states the correct action — tailored to each skill's specific failure modes.
+
+## Files to Create
+
+- `docs/plans/issue-11/plan.md`: Plan document
+- `docs/plans/issue-11/implementation.md`: Step-by-step implementation doc
+
+## Files to Modify
+
+- `.claude/skills/dev-implement/SKILL.md`: Add rationalization prevention table between PREAMBLE and STEP 1 (after line 53)
+- `.claude/skills/dev-plan/SKILL.md`: Add rationalization prevention table between PREAMBLE and STEP 1 (after line 46)
+- `.claude/skills/dev-parallel/SKILL.md`: Add rationalization prevention table between PREAMBLE and STEP 1 (after line 44)
+
+## Implementation Steps
+
+1. **Add rationalization table to `dev-implement/SKILL.md`**
+   - Insert `## RATIONALIZATION PREVENTION` section with >=5 entries tailored to implementation failure modes (skipping review, skipping tests, skipping build, batching commits, assuming trivial)
+   - Expected: New section between PREAMBLE `---` and `## STEP 1`
+
+2. **Add rationalization table to `dev-plan/SKILL.md`**
+   - Insert `## RATIONALIZATION PREVENTION` section with >=5 entries tailored to planning failure modes (skipping brainstorming, skipping security assessment, skipping version validation, rushing confirmation, skipping code reading)
+   - Expected: New section between PREAMBLE `---` and `## STEP 1`
+
+3. **Add rationalization table to `dev-parallel/SKILL.md`**
+   - Insert `## RATIONALIZATION PREVENTION` section with >=5 entries tailored to parallel execution failure modes (skipping review stages, merging without verification, rushing subagent dispatch, skipping conflict check, assuming independence)
+   - Expected: New section between PREAMBLE `---` and `## STEP 1`
+
+## Test Cases
+
+- **Happy path**: Read each updated skill file — verify rationalization table appears before STEP 1 with >=5 entries in 3-column format
+- **Edge case**: Table entries cover both code-change rationalizations and verification-step rationalizations
+- **Error case**: N/A — documentation-only change
+
+## Security Considerations
+
+No security-relevant attack surfaces identified for this issue.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|--------------|
+| AC-1 | Tables added to all three skill files (Steps 1-3) |
+| AC-2 | Each table has >=5 entries with thought pattern, counter, and required action |
+| AC-3 | Tables placed between PREAMBLE and STEP 1 in each file |
+| AC-4 | Three-column format: Thought / Why it's wrong / What to do |
+
+## Definition of Done
+
+- [ ] All ACs checked
+- [ ] Each table has >=5 skill-specific entries
+- [ ] Tables are between PREAMBLE and STEP 1 in each file
+- [ ] 3-column markdown format matches SRS example

--- a/docs/plans/issue-11/test-plan.md
+++ b/docs/plans/issue-11/test-plan.md
@@ -1,0 +1,43 @@
+---
+issue: 11
+title: Add rationalization prevention tables to dev-implement, dev-plan, dev-parallel
+branch: feature/11-rationalization-prevention-tables
+type: manual-verification
+---
+
+## Test Plan — Issue #11: Add rationalization prevention tables
+
+### Test Framework: Manual verification (read-based)
+
+This is a documentation-only change. There is no runtime code, no test framework, and no executable tests. Verification is done by reading the modified files and checking structural requirements.
+
+### Test Cases
+
+#### Happy Path
+
+| # | AC | Type | Description | Input | Expected |
+|---|---|----|-------------|-------|----------|
+| 1 | AC-1 | verify | Tables present in all 3 files | Read `dev-implement/SKILL.md` | Contains `## RATIONALIZATION PREVENTION` section |
+| 2 | AC-1 | verify | Tables present in all 3 files | Read `dev-plan/SKILL.md` | Contains `## RATIONALIZATION PREVENTION` section |
+| 3 | AC-1 | verify | Tables present in all 3 files | Read `dev-parallel/SKILL.md` | Contains `## RATIONALIZATION PREVENTION` section |
+| 4 | AC-2 | verify | Each table has >=5 entries | Count table rows in each file | >= 5 data rows per table |
+| 5 | AC-3 | verify | Tables before STEP 1 | Check section order in each file | `## RATIONALIZATION PREVENTION` appears before `## STEP 1` |
+| 6 | AC-4 | verify | 3-column format | Check table headers | Headers: `Thought | Why it's wrong | What to do` |
+
+#### Edge Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|---|----|-------------|-------|----------|
+| 7 | AC-2 | verify | Entries cover code changes | Read table entries | At least one entry about code-change rationalization per file |
+| 8 | AC-2 | verify | Entries cover verification steps | Read table entries | At least one entry about verification-skip rationalization per file |
+| 9 | AC-2 | verify | Tables are skill-specific | Compare tables across files | Tables differ — tailored to each skill's failure modes |
+
+#### Error / Failure Cases
+
+| # | AC | Type | Description | Input | Expected |
+|---|---|----|-------------|-------|----------|
+| — | — | — | N/A — documentation-only change | — | — |
+
+### Coverage Target
+
+- N/A — no executable code


### PR DESCRIPTION
## Summary
- Add rationalization prevention tables to `dev-implement`, `dev-plan`, and `dev-parallel` skill files
- Each table has 7 entries tailored to each skill's specific failure modes
- Tables placed between PREAMBLE and STEP 1 sections in 3-column markdown format (Thought | Why it's wrong | What to do)
- Documentation-only change — no runtime code or logic modifications
- Implements SRS FR-05 rationalization prevention requirement

## Changes
- `.claude/skills/dev-implement/SKILL.md` — added implementation-specific rationalization table (7 entries)
- `.claude/skills/dev-plan/SKILL.md` — added planning-specific rationalization table (7 entries)
- `.claude/skills/dev-parallel/SKILL.md` — added parallel-execution-specific rationalization table (7 entries)
- `docs/plans/issue-11/plan.md` — plan document
- `docs/plans/issue-11/implementation.md` — implementation doc (all steps done)
- `docs/plans/issue-11/test-plan.md` — manual verification test plan

## Test Plan
- [ ] Verify `## RATIONALIZATION PREVENTION` section present in all 3 skill files
- [ ] Verify each table has ≥5 entries (actual: 7 each)
- [ ] Verify tables appear before `## STEP 1` in each file
- [ ] Verify 3-column format: Thought | Why it's wrong | What to do
- [ ] Verify tables are skill-specific (not identical across files)
- [ ] Verify at least one entry per file covers code-change rationalization
- [ ] Verify at least one entry per file covers verification-skip rationalization

## Acceptance Criteria
- [x] AC-1: Rationalization prevention tables added to `dev-implement`, `dev-plan`, and `dev-parallel`
- [x] AC-2: Each table contains at least 5 common rationalizations with corresponding counters and required actions
- [x] AC-3: Tables are placed before the main execution loop in each skill file
- [x] AC-4: Each table entry has three columns: the thought pattern, why it's wrong, and the correct action

## Notes
- Tables are structural rules — they cannot be overridden by agent reasoning
- Each skill's table is tailored to its specific failure modes (implementation vs planning vs parallel execution)
- No build/lint/test commands configured for this project (documentation-only repo)

Closes #11