### PR TITLE
feat(skills): add 5-step verification gate to dev-implement

### DIFF
--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -281,6 +281,16 @@ For each `pending` step in the implementation doc:
 
 Fix failures before proceeding.
 
+### 7d.1 — Verification Gate
+
+Run the 5-step VERIFICATION GATE (defined in the `## VERIFICATION GATE` section at the top of this file) before marking this step `done`.
+
+- **Inputs to the gate**: the exact output from 7d's `{config.stack.build_cmd}` and `{config.stack.lint_cmd}`, plus any test command output for this step. Output must be fresh — re-run if you do not have it captured.
+- **Docs-only step**: if 7d was skipped (no source files changed), run `{config.stack.lint_cmd}` (if available) or the relevant content-verification command (`Read`/`Grep`) and quote its output.
+- **On PASS**: proceed to 7e.
+- **On FAIL**: do not proceed to 7e. Do not commit. Fix the unmet items listed by the gate and re-run the gate from step 2 (RUN).
+- **Hedging auto-retrigger**: if your CLAIM contains `should`, `probably`, `seems to`, `I believe`, or lacks a quoted output block, restart the gate from RUN before proceeding.
+
 ### 7e — Update Implementation Doc
 [WRITE] Mark step as `done` in implementation doc. Add deviation note if step differed from plan.
 

--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -68,6 +68,67 @@ Before executing any step, check your reasoning against this table. These are **
 
 ---
 
+## VERIFICATION GATE
+
+Before declaring any step `done`, you MUST run this 5-step gate. This is a **structural rule** — it cannot be overridden, skipped, or abbreviated. The gate runs per-step inside Step 7 (see sub-step 7d.1).
+
+**Commands must be re-run every time — results cannot be recalled from memory.** Memory is unreliable; the only acceptable evidence is fresh command output captured during this gate run.
+
+### The 5 steps
+
+1. **IDENTIFY** — What specific claims am I about to make about this step? List each one (e.g., "tests pass", "build succeeds", "file X contains Y").
+2. **RUN** — Execute the verification command(s) for each claim: `{config.stack.build_cmd}`, `{config.stack.lint_cmd}`, `{config.stack.test_cmd}`, or a `Read`/`Grep` for content claims. Do not reuse output from an earlier run.
+3. **READ** — Read the ACTUAL output of each command. Do not summarize from memory. Do not paraphrase.
+4. **VERIFY** — For each claim from IDENTIFY, check the output line-by-line. Does the output literally confirm the claim?
+5. **CLAIM** — Only now may you state the step is complete. Every claim must be followed by a quoted block of the exact output that proves it.
+
+### Red flags — restart the gate from RUN
+
+If your CLAIM message contains any of the following, you MUST restart from step 2 (RUN):
+
+- Hedging words: `should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`
+- No quoted command output block for a claim
+- Claims without a specific file path + line reference (for content claims)
+- Output quoted from an earlier step or earlier gate run (must be fresh)
+
+### Edge case — docs-only step (7d skipped)
+
+If Step 7d was skipped because no source files changed, the gate still runs: execute `{config.stack.lint_cmd}` (if available) or the relevant `Read`/`Grep` command to verify the docs claim, and quote that output in CLAIM.
+
+### PASS format
+
+```
+GATE: PASS
+
+Claims verified:
+1. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+2. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+```
+
+### FAIL format
+
+If any claim cannot be verified, the gate FAILS and the step stays `pending`. Do not proceed to 7e. Do not commit.
+
+```
+GATE: FAIL
+
+Unmet items:
+1. Claim "<claim>" — <reason, e.g., "no output quoted", "output shows 2 failures", "hedging language used">
+2. Claim "<claim>" — <reason>
+
+Next action: fix the missing evidence above and re-run the gate from step 2 (RUN).
+```
+
+---
+
 ## STEP 1 — Load Config
 
 [READ] `.paadhai.json` — hard stop if missing:

--- a/docs/plans/issue-12/implementation.md
+++ b/docs/plans/issue-12/implementation.md
@@ -9,7 +9,7 @@ branch: feature/12-verification-gate-dev-implement
 | Step | Description                                                  | Status  |
 |------|--------------------------------------------------------------|---------|
 | 1    | Insert `## VERIFICATION GATE` section into dev-implement     | done    |
-| 2    | Insert `### 7d.1 — Verification Gate` sub-step into Step 7   | pending |
+| 2    | Insert `### 7d.1 — Verification Gate` sub-step into Step 7   | done    |
 | 3    | Verify edits and confirm all ACs addressed                   | pending |
 
 ---

--- a/docs/plans/issue-12/implementation.md
+++ b/docs/plans/issue-12/implementation.md
@@ -10,7 +10,7 @@ branch: feature/12-verification-gate-dev-implement
 |------|--------------------------------------------------------------|---------|
 | 1    | Insert `## VERIFICATION GATE` section into dev-implement     | done    |
 | 2    | Insert `### 7d.1 — Verification Gate` sub-step into Step 7   | done    |
-| 3    | Verify edits and confirm all ACs addressed                   | pending |
+| 3    | Verify edits and confirm all ACs addressed                   | done    |
 
 ---
 

--- a/docs/plans/issue-12/implementation.md
+++ b/docs/plans/issue-12/implementation.md
@@ -8,7 +8,7 @@ branch: feature/12-verification-gate-dev-implement
 
 | Step | Description                                                  | Status  |
 |------|--------------------------------------------------------------|---------|
-| 1    | Insert `## VERIFICATION GATE` section into dev-implement     | pending |
+| 1    | Insert `## VERIFICATION GATE` section into dev-implement     | done    |
 | 2    | Insert `### 7d.1 — Verification Gate` sub-step into Step 7   | pending |
 | 3    | Verify edits and confirm all ACs addressed                   | pending |
 

--- a/docs/plans/issue-12/implementation.md
+++ b/docs/plans/issue-12/implementation.md
@@ -1,0 +1,207 @@
+---
+issue: 12
+title: Add 5-step verification gate to dev-implement
+branch: feature/12-verification-gate-dev-implement
+---
+
+## Progress
+
+| Step | Description                                                  | Status  |
+|------|--------------------------------------------------------------|---------|
+| 1    | Insert `## VERIFICATION GATE` section into dev-implement     | pending |
+| 2    | Insert `### 7d.1 — Verification Gate` sub-step into Step 7   | pending |
+| 3    | Verify edits and confirm all ACs addressed                   | pending |
+
+---
+
+## Step 1 — Insert `## VERIFICATION GATE` section into `dev-implement/SKILL.md`
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+
+**Action:** Insert a new `## VERIFICATION GATE` section between the RATIONALIZATION PREVENTION table's closing `---` (line 69) and `## STEP 1 — Load Config` (line 71).
+
+**Insertion anchor:** use the `Edit` tool with this `old_string`:
+
+```
+| "I can skip lint, the code is clean" | Lint catches issues humans miss — formatting, unused vars, import order | Run `{config.stack.lint_cmd}` every time |
+
+---
+
+## STEP 1 — Load Config
+```
+
+And this `new_string`:
+
+```
+| "I can skip lint, the code is clean" | Lint catches issues humans miss — formatting, unused vars, import order | Run `{config.stack.lint_cmd}` every time |
+
+---
+
+## VERIFICATION GATE
+
+Before declaring any step `done`, you MUST run this 5-step gate. This is a **structural rule** — it cannot be overridden, skipped, or abbreviated. The gate runs per-step inside Step 7 (see sub-step 7d.1).
+
+**Commands must be re-run every time — results cannot be recalled from memory.** Memory is unreliable; the only acceptable evidence is fresh command output captured during this gate run.
+
+### The 5 steps
+
+1. **IDENTIFY** — What specific claims am I about to make about this step? List each one (e.g., "tests pass", "build succeeds", "file X contains Y").
+2. **RUN** — Execute the verification command(s) for each claim: `{config.stack.build_cmd}`, `{config.stack.lint_cmd}`, `{config.stack.test_cmd}`, or a `Read`/`Grep` for content claims. Do not reuse output from an earlier run.
+3. **READ** — Read the ACTUAL output of each command. Do not summarize from memory. Do not paraphrase.
+4. **VERIFY** — For each claim from IDENTIFY, check the output line-by-line. Does the output literally confirm the claim?
+5. **CLAIM** — Only now may you state the step is complete. Every claim must be followed by a quoted block of the exact output that proves it.
+
+### Red flags — restart the gate from RUN
+
+If your CLAIM message contains any of the following, you MUST restart from step 2 (RUN):
+
+- Hedging words: `should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`
+- No quoted command output block for a claim
+- Claims without a specific file path + line reference (for content claims)
+- Output quoted from an earlier step or earlier gate run (must be fresh)
+
+### Edge case — docs-only step (7d skipped)
+
+If Step 7d was skipped because no source files changed, the gate still runs: execute `{config.stack.lint_cmd}` (if available) or the relevant `Read`/`Grep` command to verify the docs claim, and quote that output in CLAIM.
+
+### PASS format
+
+```
+GATE: PASS
+
+Claims verified:
+1. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+2. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+```
+
+### FAIL format
+
+If any claim cannot be verified, the gate FAILS and the step stays `pending`. Do not proceed to 7e. Do not commit.
+
+```
+GATE: FAIL
+
+Unmet items:
+1. Claim "<claim>" — <reason, e.g., "no output quoted", "output shows 2 failures", "hedging language used">
+2. Claim "<claim>" — <reason>
+
+Next action: fix the missing evidence above and re-run the gate from step 2 (RUN).
+```
+
+---
+
+## STEP 1 — Load Config
+```
+
+**Expected outcome:** Reading the file again shows the new `## VERIFICATION GATE` section between the RATIONALIZATION PREVENTION table's closing `---` and `## STEP 1 — Load Config`. The section contains: the 5 numbered steps, the "commands must be re-run" rule, the red flags list with all four hedging words, the docs-only edge case, and both PASS and FAIL format blocks.
+
+**Verification (per the gate itself):**
+1. IDENTIFY: claims = "section inserted at correct anchor", "5 numbered gate steps present", "red flag list includes should/probably/seems to/I believe", "FAIL format is structured block with numbered unmet items"
+2. RUN:
+   - `Read .claude/skills/dev-implement/SKILL.md offset=68 limit=80` — confirms location and content
+   - `Grep "IDENTIFY|RUN|READ|VERIFY|CLAIM" in .claude/skills/dev-implement/SKILL.md` — confirms 5 steps
+   - `Grep "should|probably|seems to|I believe" in .claude/skills/dev-implement/SKILL.md` — confirms hedging words
+3. READ: read all three outputs fresh
+4. VERIFY: each claim confirmed by its corresponding output
+5. CLAIM: quote the three outputs under `GATE: PASS`
+
+---
+
+## Step 2 — Insert `### 7d.1 — Verification Gate` sub-step into Step 7
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+
+**Action:** Insert a new `### 7d.1 — Verification Gate` sub-step between `### 7d — Build + Lint` (ends with "Fix failures before proceeding." at line 221) and `### 7e — Update Implementation Doc` (line 223).
+
+**Insertion anchor:** use the `Edit` tool with this `old_string`:
+
+```
+Fix failures before proceeding.
+
+### 7e — Update Implementation Doc
+```
+
+And this `new_string`:
+
+```
+Fix failures before proceeding.
+
+### 7d.1 — Verification Gate
+
+Run the 5-step VERIFICATION GATE (defined in the `## VERIFICATION GATE` section at the top of this file) before marking this step `done`.
+
+- **Inputs to the gate**: the exact output from 7d's `{config.stack.build_cmd}` and `{config.stack.lint_cmd}`, plus any test command output for this step. Output must be fresh — re-run if you do not have it captured.
+- **Docs-only step**: if 7d was skipped (no source files changed), run `{config.stack.lint_cmd}` (if available) or the relevant content-verification command (`Read`/`Grep`) and quote its output.
+- **On PASS**: proceed to 7e.
+- **On FAIL**: do not proceed to 7e. Do not commit. Fix the unmet items listed by the gate and re-run the gate from step 2 (RUN).
+- **Hedging auto-retrigger**: if your CLAIM contains `should`, `probably`, `seems to`, `I believe`, or lacks a quoted output block, restart the gate from RUN before proceeding.
+
+### 7e — Update Implementation Doc
+```
+
+**Expected outcome:** Reading the file again shows `### 7d.1 — Verification Gate` between `### 7d — Build + Lint` and `### 7e — Update Implementation Doc`. The sub-step references the top-level VERIFICATION GATE section, states the blocking rule, covers the docs-only edge case, and lists the hedging-language auto-retrigger.
+
+**Verification (per the gate itself):**
+1. IDENTIFY: claims = "7d.1 inserted between 7d and 7e", "references top-level VERIFICATION GATE section", "blocking rule on FAIL present", "hedging auto-retrigger present"
+2. RUN:
+   - `Read .claude/skills/dev-implement/SKILL.md offset=215 limit=30` — shows 7d, 7d.1, 7e in order
+   - `Grep "### 7d\.1|### 7e" in .claude/skills/dev-implement/SKILL.md -n` — confirms ordering and line numbers
+3. READ: read both outputs fresh
+4. VERIFY: each claim confirmed
+5. CLAIM: quote under `GATE: PASS`
+
+---
+
+## Step 3 — Verify edits and confirm all ACs addressed
+
+**Action:** Read the modified file and run greps to confirm all 5 acceptance criteria from issue #12 are satisfied. This step produces no new file changes.
+
+**Verification commands:**
+
+```bash
+# Confirm VERIFICATION GATE section location
+Read .claude/skills/dev-implement/SKILL.md offset=68 limit=90
+
+# Confirm 7d.1 sub-step location
+Read .claude/skills/dev-implement/SKILL.md offset=215 limit=35
+
+# Confirm all 5 gate steps named
+Grep -n "IDENTIFY|^2\. \*\*RUN|^3\. \*\*READ|VERIFY|CLAIM" .claude/skills/dev-implement/SKILL.md
+
+# Confirm hedging words (AC-3)
+Grep -n "should.*probably.*seems to.*I believe|hedging" .claude/skills/dev-implement/SKILL.md
+
+# Confirm memory rule (AC-4)
+Grep -n "cannot be recalled from memory|re-run every time" .claude/skills/dev-implement/SKILL.md
+
+# Confirm FAIL format (AC-5)
+Grep -n "GATE: FAIL|Unmet items" .claude/skills/dev-implement/SKILL.md
+
+# Confirm CLAIM requires quoted output (AC-2)
+Grep -n "quoted block|Evidence:" .claude/skills/dev-implement/SKILL.md
+```
+
+**Expected outcome:** Every grep returns at least one match. Every AC from the plan's AC Mapping table can be cited by quoting a specific file + line range.
+
+**Per-AC checklist:**
+- [ ] AC-1: Gate defined + 7d.1 wiring both present — quote both section headings with line numbers
+- [ ] AC-2: "Evidence:" + quoted output block pattern visible in PASS format — quote the PASS format block
+- [ ] AC-3: Hedging words list present with restart-from-RUN rule — quote the red flags block
+- [ ] AC-4: "cannot be recalled from memory" phrase present — quote that line
+- [ ] AC-5: FAIL format has "Unmet items" numbered list + "step stays `pending`" rule — quote the FAIL format block
+
+**Verification (per the gate itself):** This step IS the verification for the whole change. Produce a single `GATE: PASS` block at the end citing all 5 ACs with quoted file evidence. If any AC cannot be verified, `GATE: FAIL` and return to Step 1 or Step 2 to fix.
+
+---
+
+## Deviations
+
+(none)

--- a/docs/plans/issue-12/plan.md
+++ b/docs/plans/issue-12/plan.md
@@ -1,0 +1,83 @@
+---
+issue: 12
+title: Add 5-step verification gate to dev-implement
+branch: feature/12-verification-gate-dev-implement
+milestone: v2.2 — Quality Guards
+status: confirmed
+confirmed_at: 2026-04-10
+---
+
+## Overview
+
+Add a mandatory 5-step verification gate (IDENTIFY → RUN → READ → VERIFY → CLAIM) to `dev-implement/SKILL.md`. The gate runs per-step inside Step 7 after build/lint succeed, and blocks marking a step complete until the agent quotes actual command output. Implements SRS FR-06 for the `dev-implement` skill (issue #13 covers `dev-parallel` and `references/claude-tools.md`).
+
+## Files to Create
+
+- `docs/plans/issue-12/plan.md`: Plan document
+- `docs/plans/issue-12/implementation.md`: Step-by-step implementation doc
+
+## Files to Modify
+
+- `.claude/skills/dev-implement/SKILL.md`:
+  1. Insert new `## VERIFICATION GATE` section between the RATIONALIZATION PREVENTION table's closing `---` and `## STEP 1 — Load Config`
+  2. Insert new sub-step `### 7d.1 — Verification Gate` between `### 7d — Build + Lint` and `### 7e — Update Implementation Doc`
+
+## Implementation Steps
+
+1. **Insert `## VERIFICATION GATE` section into `dev-implement/SKILL.md`**
+   - Placement: directly after the RATIONALIZATION PREVENTION table's closing `---` and before `## STEP 1 — Load Config`
+   - Content:
+     - Introduction paragraph: the gate is mandatory per-step and cannot be overridden
+     - Numbered 5-step list: IDENTIFY → RUN → READ → VERIFY → CLAIM (verbatim from SRS FR-06)
+     - Rule: "Commands must be re-run — results cannot be recalled from memory" (AC-4)
+     - Red flags block listing "should", "probably", "seems to", "I believe", plus "no command output quoted in the completion message"
+     - Explicit rule: "If any red flag appears in your CLAIM, restart from RUN" (AC-3)
+     - FAIL format: structured `GATE: FAIL` header with numbered unmet items; step stays `pending`; no commit until PASS (AC-5)
+     - PASS format: `GATE: PASS` followed by claims, each with a quoted output block (AC-2)
+   - Expected: New section present between RP and STEP 1, ~40 lines
+
+2. **Insert `### 7d.1 — Verification Gate` sub-step into Step 7 (Implementation Loop)**
+   - Placement: between `### 7d — Build + Lint` and `### 7e — Update Implementation Doc`
+   - Content:
+     - Reference to the `## VERIFICATION GATE` section at the top of the file
+     - Instruction: run the 5 gate steps using the exact output from 7d's build/lint plus any test command for this step
+     - Blocking rule: if the gate returns FAIL, do not proceed to 7e; fix the missing evidence and re-run the gate
+     - Edge case: if 7d was skipped (no source files), the gate must still run `{config.stack.lint_cmd}` or the test command and quote its output
+     - Auto-retrigger rule: hedging language in the CLAIM forces restart from RUN (AC-3)
+   - Expected: New sub-step ~12 lines
+
+3. **Verify edits by reading the updated file**
+   - Confirm VERIFICATION GATE section is between RATIONALIZATION PREVENTION and `## STEP 1`
+   - Confirm `### 7d.1` is between `### 7d` and `### 7e`
+   - Confirm all 5 ACs are addressed by inspection and quote the relevant lines
+
+## Test Cases
+
+- **Happy path (AC-1)**: Read updated `SKILL.md` — VERIFICATION GATE section exists before STEP 1, and sub-step 7d.1 appears between 7d and 7e. Both sections reference the 5 gate steps.
+- **Edge case (docs-only change)**: Gate text explicitly states that when 7d is skipped (no source files), the agent must still run `{config.stack.lint_cmd}` or the test command and quote its output.
+- **Error case (AC-3)**: Gate red-flag list includes all four hedging words ("should", "probably", "seems to", "I believe") and a catch-all "no command output quoted" rule with explicit re-verification instruction.
+- **Error case (AC-4)**: Gate text contains an explicit rule that commands must be re-run and results cannot be recalled from memory.
+- **Error case (AC-5)**: FAIL format is a structured block with numbered unmet items; wording states the step stays `pending` and no commit occurs until the gate returns PASS.
+
+## Security Considerations
+
+No security-relevant attack surfaces identified for this issue.
+
+## AC Mapping
+
+| AC   | How Addressed                                                                                   |
+|------|-------------------------------------------------------------------------------------------------|
+| AC-1 | Gate defined in new `## VERIFICATION GATE` section + wired into Step 7 via sub-step `### 7d.1`  |
+| AC-2 | CLAIM step and PASS format both require quoted command output (test/build/lint) in the message |
+| AC-3 | Red flags list (hedging words + missing output) with explicit restart-from-RUN rule             |
+| AC-4 | Gate text explicitly forbids recalling results from memory; mandates re-running commands        |
+| AC-5 | FAIL format is a structured block listing numbered unmet items; step blocked from completion    |
+
+## Definition of Done
+
+- [ ] `## VERIFICATION GATE` section present between RATIONALIZATION PREVENTION and `## STEP 1`
+- [ ] Sub-step `### 7d.1 — Verification Gate` present between `### 7d` and `### 7e` in Step 7
+- [ ] All 5 ACs verifiable by reading `SKILL.md`
+- [ ] Plan + implementation doc committed under `docs/plans/issue-12/`
+
+> Build / lint / test: N/A — no build stack configured for this repo (`.paadhai.json` stack is `none`); this is a docs-only change.

--- a/docs/plans/issue-12/test-plan.md
+++ b/docs/plans/issue-12/test-plan.md
@@ -1,0 +1,63 @@
+---
+issue: 12
+title: Add 5-step verification gate to dev-implement
+branch: feature/12-verification-gate-dev-implement
+type: manual-verification
+---
+
+## Test Plan — Issue #12: Add 5-step verification gate to dev-implement
+
+### Test Framework: Manual verification (read-based)
+
+This is a documentation-only change to `.claude/skills/dev-implement/SKILL.md`. There is no runtime code, no test framework, and no executable tests. Verification is done by reading the modified file and checking structural requirements via Read/Grep.
+
+### Test Cases
+
+#### Happy Path
+
+| #  | AC   | Type   | Description                                  | Input                                                                          | Expected                                                                                              |
+|----|------|--------|----------------------------------------------|--------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| 1  | AC-1 | verify | Top-level gate section present               | Grep `^## VERIFICATION GATE` in `dev-implement/SKILL.md`                       | Exactly one match                                                                                     |
+| 2  | AC-1 | verify | Gate placed before STEP 1                    | Read section order in `SKILL.md`                                               | `## VERIFICATION GATE` appears before `## STEP 1 — Load Config`                                       |
+| 3  | AC-1 | verify | Gate sub-step wired into Step 7              | Grep `^### 7d\.1 — Verification Gate`                                          | Exactly one match between `### 7d` and `### 7e`                                                       |
+| 4  | AC-1 | verify | All 5 gate phases named                      | Grep for `IDENTIFY`, `RUN`, `READ`, `VERIFY`, `CLAIM` headings                 | All 5 phase names present in the gate section                                                         |
+| 5  | AC-2 | verify | PASS format requires quoted output           | Read PASS format block                                                         | Block contains `Evidence:` followed by a fenced code block placeholder                                |
+| 6  | AC-2 | verify | CLAIM step references quoted output rule     | Grep `quoted block of the exact output`                                        | At least one match in CLAIM step description                                                          |
+
+#### Edge Cases
+
+| #  | AC   | Type   | Description                                  | Input                                                                          | Expected                                                                                              |
+|----|------|--------|----------------------------------------------|--------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| 7  | AC-1 | verify | Docs-only fallback documented                | Grep `docs-only` or `7d was skipped` in gate section                           | Match present; fallback says run `{config.stack.lint_cmd}` or `Read`/`Grep` and quote output          |
+| 8  | AC-2 | verify | Sub-step 7d.1 references top-level gate      | Read 7d.1 body                                                                 | Body references the `## VERIFICATION GATE` section                                                    |
+| 9  | AC-1 | verify | Step count in banner unchanged               | Read PREAMBLE banner block                                                     | Still says `10 steps` (7d.1 is a sub-step, not a new top-level step)                                  |
+
+#### Error / Failure Cases
+
+| #  | AC   | Type   | Description                                  | Input                                                                          | Expected                                                                                              |
+|----|------|--------|----------------------------------------------|--------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| 10 | AC-3 | verify | Hedging words listed (all 4 from issue)      | Grep `should`, `probably`, `seems to`, `I believe` in red flags block          | All 4 words present in a single red-flags list                                                        |
+| 11 | AC-3 | verify | Hedging triggers restart from RUN            | Grep `restart from .*RUN` or `restart the gate from RUN`                       | At least one match in red flags block AND in 7d.1 auto-retrigger rule                                 |
+| 12 | AC-3 | verify | Missing-quoted-output is a red flag          | Read red flags list                                                            | Bullet for "no quoted command output block for a claim"                                               |
+| 13 | AC-4 | verify | Memory-recall ban present                    | Grep `cannot be recalled from memory` or `re-run every time`                   | At least one match in gate intro paragraph                                                            |
+| 14 | AC-5 | verify | FAIL format is a structured block            | Read FAIL format block                                                         | Block has `GATE: FAIL` header + `Unmet items` numbered list                                           |
+| 15 | AC-5 | verify | FAIL blocks step completion                  | Grep `step stays \`pending\`` AND `Do not proceed to 7e`                       | Both phrases present in FAIL format block or 7d.1 sub-step                                            |
+| 16 | AC-5 | verify | FAIL blocks commit                           | Grep `Do not commit` in 7d.1 or FAIL format                                    | At least one match                                                                                    |
+
+### Per-AC Mapping
+
+| AC   | Tests                  |
+|------|------------------------|
+| AC-1 | 1, 2, 3, 4, 7, 9       |
+| AC-2 | 5, 6, 8                |
+| AC-3 | 10, 11, 12             |
+| AC-4 | 13                     |
+| AC-5 | 14, 15, 16             |
+
+### Coverage Target
+
+- N/A — no executable code. Coverage = "every AC verifiable by a Read/Grep against the modified file" (16 checks across 5 ACs).
+
+### Test Stubs
+
+N/A — no test framework (`stack.language: none`). Verification is performed inline during implementation Step 3 of `docs/plans/issue-12/implementation.md`, which already runs Read/Grep against `SKILL.md` per the gate's own format.


### PR DESCRIPTION
## Summary

- Adds a mandatory 5-step `VERIFICATION GATE` (IDENTIFY → RUN → READ → VERIFY → CLAIM) as a new top-level section in `dev-implement/SKILL.md`, placed above STEP 1 alongside the existing Rationalization Prevention table.
- Wires the gate into the implementation loop via new sub-step `### 7d.1 — Verification Gate` between `7d — Build + Lint` and `7e — Update Implementation Doc`.
- Blocks step completion on FAIL: step stays `pending`, no commit, numbered unmet items listed with "restart the gate from RUN" as the next action.
- Hedging words (`should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`) or a missing quoted-output block auto-retrigger the gate from RUN.
- Explicitly forbids recall from memory — every gate run must re-execute commands and quote fresh output.

## Changes

- `.claude/skills/dev-implement/SKILL.md` — inserted `## VERIFICATION GATE` section and `### 7d.1` sub-step
- `docs/plans/issue-12/plan.md` — plan
- `docs/plans/issue-12/implementation.md` — step-by-step implementation doc with dogfooded gate checks
- `docs/plans/issue-12/test-plan.md` — 16 manual-verification test cases across 5 ACs

## Test Plan

This is a docs-only change to a skill markdown file in a `stack.language: none` repo — no build/lint/test commands apply. Verification is manual Read/Grep against the modified `SKILL.md`, executed inline during implementation step 3.

- [x] Grep `^## VERIFICATION GATE` → 1 match at line 71
- [x] Grep `^### 7d\.1 — Verification Gate` → 1 match at line 284 (between 7d at 275 and 7e at 294)
- [x] Grep for IDENTIFY/RUN/READ/VERIFY/CLAIM headings → all 5 present (lines 79–83)
- [x] Grep `should`, `probably`, `seems to`, `I believe` → all present in red flags (line 89) and in 7d.1 auto-retrigger (line 292)
- [x] Grep `cannot be recalled from memory` → present at line 75
- [x] Grep `GATE: FAIL`, `Unmet items`, `step stays \`pending\`` → all present (lines 118, 121, 123)
- [x] PASS format contains `Evidence:` fenced blocks → present (lines 105, 110)

See `docs/plans/issue-12/test-plan.md` for the full 16-case checklist.

## Acceptance Criteria

- [x] AC-1: The 5-step verification gate is added to `dev-implement` and executed per-step before marking a step complete
- [x] AC-2: Completion messages must include quoted output from the verification command (test/build/lint result)
- [x] AC-3: Hedging language ("should", "probably", "seems to", "I believe") in a completion message triggers automatic re-verification
- [x] AC-4: The gate explicitly states that commands must be re-run — results cannot be recalled from memory
- [x] AC-5: FAIL result (unverified claim) blocks the step from being marked complete with specific unmet items listed

## Notes

- **Scope**: This PR covers `dev-implement` only. Rolling the gate out to `dev-parallel` and updating `references/claude-tools.md` is tracked separately under issue #13 (SRS FR-06).
- **Step count**: 7d.1 is a sub-step, so `dev-implement`'s banner still says "10 steps" (verified at line 9 of `SKILL.md`).
- **Dogfooded**: this PR's own implementation loop ran the new gate for every impl-step. Every commit on the branch was preceded by a `GATE: PASS` block with quoted Read/Grep output.

Closes #12