### PR TITLE
feat(dev-parallel): add [VERIFY] gate and document in claude-tools.md

### DIFF
--- a/.claude/skills/dev-parallel/SKILL.md
+++ b/.claude/skills/dev-parallel/SKILL.md
@@ -27,7 +27,7 @@ Display (with issue context):
 ```
 ────────────────────────────────────────
 dev-parallel | Issue #<number> — <title>
-14 steps | Branch: <branch>
+15 steps | Branch: <branch>
 ────────────────────────────────────────
 ```
 
@@ -35,7 +35,7 @@ Display (no issue context — not on feature/fix branch):
 ```
 ────────────────────────────────────────
 dev-parallel
-14 steps | Branch: <branch>
+15 steps | Branch: <branch>
 ────────────────────────────────────────
 ```
 
@@ -56,6 +56,8 @@ Before executing any step, check your reasoning against this table. These are **
 | "One subagent failed but the rest are fine, ship it" | Partial results leave the codebase in an inconsistent state | All subagents must pass before merging any |
 | "I can skip the final integration check" | Individual correctness doesn't guarantee combined correctness | Run build and tests after merging all results |
 | "The task grouping is obvious, no need to analyze" | Poor grouping creates coupling between subagents and merge nightmares | Analyze dependencies and group carefully (Step 2) |
+| "Subagent said GATE: PASS, I can trust it without inspecting" | The gate block can be fabricated; evidence must be present and well-formed | Always inspect each report for quoted evidence per claim (Step 8) |
+| "One missing claim isn't worth a re-dispatch" | Partial evidence = no evidence; skipping the re-dispatch normalizes missing claims | Reject the report and re-dispatch verify-only (Step 8) |
 
 ---
 
@@ -71,28 +73,29 @@ Store:
 
 ### Progress Tracking
 
-[PROGRESS] Initialize TodoWrite checklist — 14 items, all `pending`:
+[PROGRESS] Initialize TodoWrite checklist — 15 items, all `pending`:
 ```
-Step 1/14: Load Config
-Step 2/14: Load Implementation Doc
-Step 3/14: Group Independent Tasks
-Step 4/14: Generate Subagent Prompts
-Step 5/14: Dispatch Gate
-Step 6/14: Dispatch Subagents (after G-11)
-Step 7/14: Collect Results
-Step 8/14: Stage 1: Spec Compliance Review
-Step 9/14: Stage 2: Code Quality Review
-Step 10/14: Fix Loop
-Step 11/14: Update Implementation Doc
-Step 12/14: Full Test Run
-Step 13/14: Summary
-Step 14/14: Handoff
+Step 1/15: Load Config
+Step 2/15: Load Implementation Doc
+Step 3/15: Group Independent Tasks
+Step 4/15: Generate Subagent Prompts
+Step 5/15: Dispatch Gate
+Step 6/15: Dispatch Subagents (after G-11)
+Step 7/15: Collect Results
+Step 8/15: Validate Subagent Reports
+Step 9/15: Stage 1: Spec Compliance Review
+Step 10/15: Stage 2: Code Quality Review
+Step 11/15: Fix Loop
+Step 12/15: Update Implementation Doc
+Step 13/15: Full Test Run
+Step 14/15: Summary
+Step 15/15: Handoff
 ```
 (Graceful degradation: skip if TodoWrite unavailable)
 
-[PROGRESS] Mark Step 1/14 `completed`:
+[PROGRESS] Mark Step 1/15 `completed`:
 ```
-Step 1/14: Load Config [completed]
+Step 1/15: Load Config [completed]
 Files read: .paadhai.json
 ```
 
@@ -100,7 +103,7 @@ Files read: .paadhai.json
 
 ## STEP 2 — Load Implementation Doc
 
-[PROGRESS] Mark Step 2/14 `in_progress`: `Step 2/14: Load Implementation Doc [in_progress]`
+[PROGRESS] Mark Step 2/15 `in_progress`: `Step 2/15: Load Implementation Doc [in_progress]`
 
 [SHELL] Get current branch:
 ```bash
@@ -119,14 +122,14 @@ Steps     : <total count>
 Doc path  : docs/plans/issue-<n>/implementation.md
 ```
 
-[PROGRESS] Mark Step 2/14 `completed`: `Step 2/14: Load Implementation Doc [completed]`
+[PROGRESS] Mark Step 2/15 `completed`: `Step 2/15: Load Implementation Doc [completed]`
 `Files read: docs/plans/issue-<n>/implementation.md, docs/plans/issue-<n>/plan.md`
 
 ---
 
 ## STEP 3 — Group Independent Tasks
 
-[PROGRESS] Mark Step 3/14 `in_progress`: `Step 3/14: Group Independent Tasks [in_progress]`
+[PROGRESS] Mark Step 3/15 `in_progress`: `Step 3/15: Group Independent Tasks [in_progress]`
 
 Scan implementation steps and build a dependency graph:
 - **Sequential**: step B requires step A's output (shared file, import, or state)
@@ -148,14 +151,14 @@ Group | Steps       | Files Touched          | Dependencies
 If no independent groups found (all sequential) → stop:
 > All tasks are sequential. Use `/paadhai:dev-implement` in sequential mode instead.
 
-[PROGRESS] Mark Step 3/14 `completed`: `Step 3/14: Group Independent Tasks [completed]`
+[PROGRESS] Mark Step 3/15 `completed`: `Step 3/15: Group Independent Tasks [completed]`
 `Task groups identified`
 
 ---
 
 ## STEP 4 — Generate Subagent Prompts
 
-[PROGRESS] Mark Step 4/14 `in_progress`: `Step 4/14: Generate Subagent Prompts [in_progress]`
+[PROGRESS] Mark Step 4/15 `in_progress`: `Step 4/15: Generate Subagent Prompts [in_progress]`
 
 For each independent task group, build a prompt containing:
 
@@ -173,31 +176,59 @@ For each independent task group, build a prompt containing:
    - `git add <specific-files>` — never `git add -A`
    - Run `{config.stack.build_cmd}` and `{config.stack.lint_cmd}` after changes
    - Mark each step as `done` in implementation.md after completion
-6. **Report format**: files changed, build status, lint status, commit SHA
+   - **Before reporting, run the `[VERIFY]` gate defined in `references/claude-tools.md § [VERIFY] Convention`.** Your report MUST end with a `GATE: PASS` block containing quoted command output for every claim. Reports without this block will be rejected by the orchestrator and re-dispatched.
+6. **Report format**:
+   ```
+   ## Report
+
+   Files changed : <list>
+   Commit SHA    : <sha>
+
+   ## [VERIFY] Gate
+
+   GATE: PASS
+
+   Claims verified:
+   1. Build succeeds
+      Evidence:
+      ```
+      <quoted output of {config.stack.build_cmd}>
+      ```
+   2. Lint clean
+      Evidence:
+      ```
+      <quoted output of {config.stack.lint_cmd}>
+      ```
+   3. Assigned step(s) marked `done` in implementation.md
+      Evidence:
+      ```
+      <quoted grep/read output showing "status: done" for each assigned step>
+      ```
+   ```
 
 Display all generated prompts to user for review.
 
-[PROGRESS] Mark Step 4/14 `completed`: `Step 4/14: Generate Subagent Prompts [completed]`
+[PROGRESS] Mark Step 4/15 `completed`: `Step 4/15: Generate Subagent Prompts [completed]`
 `Prompts generated`
 
 ---
 
 ## STEP 5 — Dispatch Gate
 
-[PROGRESS] Mark Step 5/14 `in_progress`: `Step 5/14: Dispatch Gate [in_progress]`
+[PROGRESS] Mark Step 5/15 `in_progress`: `Step 5/15: Dispatch Gate [in_progress]`
 
 **G-11: "Dispatch <N> subagents for parallel implementation? (yes/no)"**
 
 Wait for explicit "yes". Do not proceed without it.
 
-[PROGRESS] Mark Step 5/14 `completed`: `Step 5/14: Dispatch Gate [completed]`
+[PROGRESS] Mark Step 5/15 `completed`: `Step 5/15: Dispatch Gate [completed]`
 `Gate passed`
 
 ---
 
 ## STEP 6 — Dispatch Subagents (after G-11)
 
-[PROGRESS] Mark Step 6/14 `in_progress`: `Step 6/14: Dispatch Subagents (after G-11) [in_progress]`
+[PROGRESS] Mark Step 6/15 `in_progress`: `Step 6/15: Dispatch Subagents (after G-11) [in_progress]`
 
 [PARALLEL] Dispatch one `[DELEGATE][FAST-MODEL]` per independent task group.
 
@@ -216,14 +247,14 @@ Each subagent:
 
 Sequential groups (those depending on earlier groups) are dispatched only after their dependencies complete.
 
-[PROGRESS] Mark Step 6/14 `completed`: `Step 6/14: Dispatch Subagents (after G-11) [completed]`
+[PROGRESS] Mark Step 6/15 `completed`: `Step 6/15: Dispatch Subagents (after G-11) [completed]`
 `Subagents dispatched`
 
 ---
 
 ## STEP 7 — Collect Results
 
-[PROGRESS] Mark Step 7/14 `in_progress`: `Step 7/14: Collect Results [in_progress]`
+[PROGRESS] Mark Step 7/15 `in_progress`: `Step 7/15: Collect Results [in_progress]`
 
 Wait for all subagents to complete.
 
@@ -245,14 +276,82 @@ If any group failed:
 - If skip → mark those steps as `pending` in implementation.md
 - If abort → stop
 
-[PROGRESS] Mark Step 7/14 `completed`: `Step 7/14: Collect Results [completed]`
+[PROGRESS] Mark Step 7/15 `completed`: `Step 7/15: Collect Results [completed]`
 `Results collected`
 
 ---
 
-## STEP 8 — Stage 1: Spec Compliance Review
+## STEP 8 — Validate Subagent Reports
 
-[PROGRESS] Mark Step 8/14 `in_progress`: `Step 8/14: Stage 1: Spec Compliance Review [in_progress]`
+[PROGRESS] Mark Step 8/15 `in_progress`: `Step 8/15: Validate Subagent Reports [in_progress]`
+
+Every subagent report MUST pass the `[VERIFY]` structural validation before the orchestrator accepts it. The orchestrator does NOT re-run verification commands — it inspects the report text for evidence produced by the subagent's own gate run (defined in `references/claude-tools.md § [VERIFY] Convention`).
+
+### Validation checks (text inspection, inline — no subagent delegation)
+
+For each subagent report:
+
+1. **Presence** — Does the report contain a `GATE: PASS` block?
+   - If no → **REJECT**: missing gate
+
+2. **Evidence** — For each claim listed under `Claims verified:`, is there a fenced code block containing command output directly beneath it?
+   - If any claim lacks a fenced evidence block → **REJECT**: claim "<X>" has no quoted evidence
+
+3. **Hedging** — Does the report contain any red-flag language (outside of fenced code blocks)?
+   Red flags: `should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`
+   - If any red flag appears in prose → **REJECT**: hedging in "<quoted sentence>"
+
+### On REJECT → verify-only re-dispatch
+
+[DELEGATE][FAST-MODEL] Dispatch a new subagent (same task group), with a narrower prompt:
+
+```
+The previous subagent for group <N> produced a report that failed [VERIFY] validation.
+Reason: <reject reason>
+
+Previous report:
+<quoted bad report>
+
+Your task: verify-only. Do NOT modify code — the work is already committed.
+1. [READ] the files listed in "Files changed" of the previous report
+2. Run {config.stack.build_cmd}, {config.stack.lint_cmd}, and {config.stack.test_cmd} (if applicable) against the current state
+3. Produce a new report with a well-formed GATE: PASS block including quoted command output for every claim
+4. Do NOT use hedging language
+```
+
+### Retry cap + escalation
+
+- **1 retry** per group.
+- If the verify-only re-dispatch ALSO fails validation → stop and escalate to the user:
+
+```
+Subagent for group <N> failed verification twice.
+
+Last report:
+<quoted bad report>
+
+Reject reason: <reason>
+
+Options:
+  retry  — dispatch a third verify-only subagent
+  manual — you fix and re-run the gate yourself
+  abort  — stop dev-parallel, leave work in place
+```
+
+Wait for explicit user choice. Do not proceed without it.
+
+### On all reports PASS
+
+Proceed to Step 9 (Stage 1: Spec Compliance Review).
+
+[PROGRESS] Mark Step 8/15 `completed`: `Step 8/15: Validate Subagent Reports [completed]`
+`All reports passed [VERIFY] validation`
+
+---
+
+## STEP 9 — Stage 1: Spec Compliance Review
+
+[PROGRESS] Mark Step 9/15 `in_progress`: `Step 9/15: Stage 1: Spec Compliance Review [in_progress]`
 
 [DELEGATE][SMART-MODEL] Review ALL changes against implementation.md:
 
@@ -265,14 +364,14 @@ Check:
 
 Report: **PASS** / **FAIL** with specific gaps listed.
 
-[PROGRESS] Mark Step 8/14 `completed`: `Step 8/14: Stage 1: Spec Compliance Review [completed]`
+[PROGRESS] Mark Step 9/15 `completed`: `Step 9/15: Stage 1: Spec Compliance Review [completed]`
 `Spec review: PASS`
 
 ---
 
-## STEP 9 — Stage 2: Code Quality Review
+## STEP 10 — Stage 2: Code Quality Review
 
-[PROGRESS] Mark Step 9/14 `in_progress`: `Step 9/14: Stage 2: Code Quality Review [in_progress]`
+[PROGRESS] Mark Step 10/15 `in_progress`: `Step 10/15: Stage 2: Code Quality Review [in_progress]`
 
 [DELEGATE][SMART-MODEL] Review ALL changes for:
 
@@ -286,14 +385,14 @@ Check:
 
 Report: **PASS** / **FAIL** with specific issues listed.
 
-[PROGRESS] Mark Step 9/14 `completed`: `Step 9/14: Stage 2: Code Quality Review [completed]`
+[PROGRESS] Mark Step 10/15 `completed`: `Step 10/15: Stage 2: Code Quality Review [completed]`
 `Code review: PASS`
 
 ---
 
-## STEP 10 — Fix Loop
+## STEP 11 — Fix Loop
 
-[PROGRESS] Mark Step 10/14 `in_progress`: `Step 10/14: Fix Loop [in_progress]`
+[PROGRESS] Mark Step 11/15 `in_progress`: `Step 11/15: Fix Loop [in_progress]`
 
 If either review reports **FAIL**:
 1. Display all findings
@@ -308,27 +407,27 @@ If either review reports **FAIL**:
 4. Re-run only the failed review stage (Stage 1 or Stage 2)
 5. Repeat until both stages report **PASS**
 
-[PROGRESS] Mark Step 10/14 `completed`: `Step 10/14: Fix Loop [completed]`
+[PROGRESS] Mark Step 11/15 `completed`: `Step 11/15: Fix Loop [completed]`
 `Fixes applied`
 
 ---
 
-## STEP 11 — Update Implementation Doc
+## STEP 12 — Update Implementation Doc
 
-[PROGRESS] Mark Step 11/14 `in_progress`: `Step 11/14: Update Implementation Doc [in_progress]`
+[PROGRESS] Mark Step 12/15 `in_progress`: `Step 12/15: Update Implementation Doc [in_progress]`
 
 [READ] `docs/plans/issue-<n>/implementation.md`
 
 [WRITE] Mark all completed steps as `done`. Add deviation notes if any step differed from the original plan.
 
-[PROGRESS] Mark Step 11/14 `completed`: `Step 11/14: Update Implementation Doc [completed]`
+[PROGRESS] Mark Step 12/15 `completed`: `Step 12/15: Update Implementation Doc [completed]`
 `Files changed: docs/plans/issue-<n>/implementation.md`
 
 ---
 
-## STEP 12 — Full Test Run
+## STEP 13 — Full Test Run
 
-[PROGRESS] Mark Step 12/14 `in_progress`: `Step 12/14: Full Test Run [in_progress]`
+[PROGRESS] Mark Step 13/15 `in_progress`: `Step 13/15: Full Test Run [in_progress]`
 
 [SHELL] Run all checks:
 ```bash
@@ -339,14 +438,14 @@ If either review reports **FAIL**:
 
 If any fail → fix failures before proceeding. Do not skip.
 
-[PROGRESS] Mark Step 12/14 `completed`: `Step 12/14: Full Test Run [completed]`
+[PROGRESS] Mark Step 13/15 `completed`: `Step 13/15: Full Test Run [completed]`
 `Build: ✓  Lint: ✓  Tests: <count> passing`
 
 ---
 
-## STEP 13 — Summary
+## STEP 14 — Summary
 
-[PROGRESS] Mark Step 13/14 `in_progress`: `Step 13/14: Summary [in_progress]`
+[PROGRESS] Mark Step 14/15 `in_progress`: `Step 14/15: Summary [in_progress]`
 
 Display:
 ```
@@ -362,14 +461,14 @@ Spec Review  : PASS
 Code Review  : PASS
 ```
 
-[PROGRESS] Mark Step 13/14 `completed`: `Step 13/14: Summary [completed]`
+[PROGRESS] Mark Step 14/15 `completed`: `Step 14/15: Summary [completed]`
 `Output displayed`
 
 ---
 
-## STEP 14 — Handoff
+## STEP 15 — Handoff
 
-[PROGRESS] Mark Step 14/14 `in_progress`: `Step 14/14: Handoff [in_progress]`
+[PROGRESS] Mark Step 15/15 `in_progress`: `Step 15/15: Handoff [in_progress]`
 
 ```
 Run /dev-pr to push the branch and open a pull request.
@@ -378,5 +477,5 @@ Branch  : <branch-name>
 Issue   : #<number>
 ```
 
-[PROGRESS] Mark Step 14/14 `completed`: `Step 14/14: Handoff [completed]`
+[PROGRESS] Mark Step 15/15 `completed`: `Step 15/15: Handoff [completed]`
 `Output displayed`

--- a/docs/plans/issue-13/implementation.md
+++ b/docs/plans/issue-13/implementation.md
@@ -1,0 +1,597 @@
+---
+issue: 13
+title: Add verification gate to dev-parallel and document in claude-tools.md
+branch: feature/13-add-verification-gate-dev-parallel
+---
+
+# Implementation Doc — Issue #13
+
+## Progress Table
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Add `[VERIFY]` marker row to claude-tools.md table | pending |
+| 2 | Add `## [VERIFY] Convention` section to claude-tools.md | pending |
+| 3 | Commit 1 — docs(claude-tools) | pending |
+| 4 | Add 2 rationalization rows to dev-parallel | pending |
+| 5 | Update preamble step count 14 → 15 | pending |
+| 6 | Update Step 1 TodoWrite checklist (14 → 15 items) | pending |
+| 7 | Update Step 4 subagent prompt (new rules + report format) | pending |
+| 8 | Insert new Step 8 — Validate Subagent Reports | pending |
+| 9 | Renumber old Steps 8–14 to 9–15 | pending |
+| 10 | Commit 2 — feat(dev-parallel) | pending |
+
+---
+
+## Step 1 — Add `[VERIFY]` marker row to claude-tools.md table
+
+**File:** `references/claude-tools.md`
+
+**Tool:** `Edit`
+
+**Find** (exact text, lines 16–17):
+```
+| `[PROGRESS]` | `TodoWrite` tool | Create and update a live step checklist. Graceful degradation: skip if TodoWrite unavailable |
+
+## Subagent Support
+```
+
+**Replace with:**
+```
+| `[PROGRESS]` | `TodoWrite` tool | Create and update a live step checklist. Graceful degradation: skip if TodoWrite unavailable |
+| `[VERIFY]` | Inline text inspection | Run the 5-step verification gate before claiming a task complete. See `## [VERIFY] Convention` below. |
+
+## Subagent Support
+```
+
+**Expected output:** Edit succeeds. File now has a `[VERIFY]` row after `[PROGRESS]`.
+
+**Verification command:**
+```bash
+grep -n "\[VERIFY\]" references/claude-tools.md
+```
+
+**Expected verification output:** At least one line showing `| \`[VERIFY]\` | Inline text inspection |`.
+
+---
+
+## Step 2 — Add `## [VERIFY] Convention` section to claude-tools.md
+
+**File:** `references/claude-tools.md`
+
+**Tool:** `Edit`
+
+**Find** (exact text — the final section of the file, lines 70–71):
+```
+If the TodoWrite tool is unavailable, skip all `[PROGRESS]` calls silently and continue execution. Never block on progress tracking.
+```
+
+**Replace with:**
+```
+If the TodoWrite tool is unavailable, skip all `[PROGRESS]` calls silently and continue execution. Never block on progress tracking.
+
+## [VERIFY] Convention
+
+`[VERIFY]` marks a mandatory 5-step verification gate that must run before a skill (or subagent) declares a task complete. The gate produces quoted command output as evidence, so a reviewer can confirm the claim without re-running the commands.
+
+**Commands must be re-run every time — results cannot be recalled from memory.** Memory is unreliable; the only acceptable evidence is fresh command output captured during this gate run.
+
+### The 5 steps
+
+1. **IDENTIFY** — What specific claims am I about to make about this task? List each one (e.g., "tests pass", "build succeeds", "file X contains Y").
+2. **RUN** — Execute the verification command(s) for each claim: `{config.stack.build_cmd}`, `{config.stack.lint_cmd}`, `{config.stack.test_cmd}`, or a `Read`/`Grep` for content claims. Do not reuse output from an earlier run.
+3. **READ** — Read the ACTUAL output of each command. Do not summarize from memory. Do not paraphrase.
+4. **VERIFY** — For each claim from IDENTIFY, check the output line-by-line. Does the output literally confirm the claim?
+5. **CLAIM** — Only now may you state the task is complete. Every claim must be followed by a quoted block of the exact output that proves it.
+
+### Red flags — restart the gate from RUN
+
+If your CLAIM message contains any of the following, you MUST restart from step 2 (RUN):
+
+- Hedging words: `should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`
+- No quoted command output block for a claim
+- Claims without a specific file path + line reference (for content claims)
+- Output quoted from an earlier task or earlier gate run (must be fresh)
+
+### Edge case — docs-only task
+
+If no source files changed, the gate still runs: execute `{config.stack.lint_cmd}` (if available) or the relevant `Read`/`Grep` command to verify the docs claim, and quote that output in CLAIM.
+
+### PASS format
+
+```
+GATE: PASS
+
+Claims verified:
+1. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+2. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+```
+
+### FAIL format
+
+If any claim cannot be verified, the gate FAILS and the task stays `pending`. Do not proceed. Do not commit.
+
+```
+GATE: FAIL
+
+Unmet items:
+1. Claim "<claim>" — <reason, e.g., "no output quoted", "output shows 2 failures", "hedging language used">
+2. Claim "<claim>" — <reason>
+
+Next action: fix the missing evidence above and re-run the gate from step 2 (RUN).
+```
+
+### Usage across skills
+
+- **`dev-implement`** applies the gate per-step inside its implementation loop (§ VERIFICATION GATE in that skill's SKILL.md).
+- **`dev-parallel`** requires each subagent to run the gate on its own work and include the PASS block in its report. The orchestrator validates the report structure (Step 8 of dev-parallel) before accepting results.
+- **Future skills** may reference this convention by writing `[VERIFY] Run the gate before declaring <task> complete` in the relevant step.
+```
+
+**Expected output:** Edit succeeds. File now ends with a full `## [VERIFY] Convention` section.
+
+**Verification command:**
+```bash
+grep -n "## \[VERIFY\] Convention" references/claude-tools.md
+grep -c "IDENTIFY\|RUN\|READ\|VERIFY\|CLAIM" references/claude-tools.md
+```
+
+**Expected verification output:** First command shows the section header line. Second command shows a count ≥ 5 (the 5 gate step names).
+
+---
+
+## Step 3 — Commit 1
+
+**Tool:** `Bash`
+
+**Commands:**
+```bash
+git add references/claude-tools.md
+git status
+git commit -m "docs(claude-tools): add [VERIFY] marker and convention
+
+Add [VERIFY] to the capability marker table and a full ## [VERIFY]
+Convention section documenting the 5-step verification gate, red-flag
+list, PASS/FAIL formats, and cross-skill usage notes. This makes the
+verification gate a reusable pattern for future skills.
+
+Refs #13"
+```
+
+**Expected output:** `git status` shows only `references/claude-tools.md` staged. Commit succeeds with 1 file changed.
+
+**Verification command:**
+```bash
+git log -1 --stat
+```
+
+**Expected verification output:** Latest commit is `docs(claude-tools): add [VERIFY] marker and convention`, 1 file changed, `references/claude-tools.md` only.
+
+---
+
+## Step 4 — Add 2 rationalization rows to dev-parallel
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Tool:** `Edit`
+
+**Find** (exact text, line 58, the last row of the rationalization table):
+```
+| "The task grouping is obvious, no need to analyze" | Poor grouping creates coupling between subagents and merge nightmares | Analyze dependencies and group carefully (Step 2) |
+```
+
+**Replace with:**
+```
+| "The task grouping is obvious, no need to analyze" | Poor grouping creates coupling between subagents and merge nightmares | Analyze dependencies and group carefully (Step 2) |
+| "Subagent said GATE: PASS, I can trust it without inspecting" | The gate block can be fabricated; evidence must be present and well-formed | Always inspect each report for quoted evidence per claim (Step 8) |
+| "One missing claim isn't worth a re-dispatch" | Partial evidence = no evidence; skipping the re-dispatch normalizes missing claims | Reject the report and re-dispatch verify-only (Step 8) |
+```
+
+**Expected output:** Edit succeeds. Rationalization table now has 9 rows instead of 7.
+
+**Verification command:**
+```bash
+grep -c "^| \"" .claude/skills/dev-parallel/SKILL.md
+```
+
+**Expected verification output:** Count should be 9 (7 original + 2 new rationalization rows).
+
+---
+
+## Step 5 — Update preamble step count 14 → 15
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Tool:** `Edit` with `replace_all: true`
+
+**Find:**
+```
+14 steps | Branch: <branch>
+```
+
+**Replace with:**
+```
+15 steps | Branch: <branch>
+```
+
+**Expected output:** Edit succeeds, 2 replacements (both banner variants).
+
+**Verification command:**
+```bash
+grep -n "14 steps\|15 steps" .claude/skills/dev-parallel/SKILL.md
+```
+
+**Expected verification output:** Zero lines matching `14 steps`. Two lines matching `15 steps`.
+
+---
+
+## Step 6 — Update Step 1 TodoWrite checklist (14 → 15 items)
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Tool:** `Edit`
+
+**Find** (exact text, the current checklist block inside Step 1):
+```
+[PROGRESS] Initialize TodoWrite checklist — 14 items, all `pending`:
+```
+Step 1/14: Load Config
+Step 2/14: Load Implementation Doc
+Step 3/14: Group Independent Tasks
+Step 4/14: Generate Subagent Prompts
+Step 5/14: Dispatch Gate
+Step 6/14: Dispatch Subagents (after G-11)
+Step 7/14: Collect Results
+Step 8/14: Stage 1: Spec Compliance Review
+Step 9/14: Stage 2: Code Quality Review
+Step 10/14: Fix Loop
+Step 11/14: Update Implementation Doc
+Step 12/14: Full Test Run
+Step 13/14: Summary
+Step 14/14: Handoff
+```
+```
+
+**Replace with:**
+```
+[PROGRESS] Initialize TodoWrite checklist — 15 items, all `pending`:
+```
+Step 1/15: Load Config
+Step 2/15: Load Implementation Doc
+Step 3/15: Group Independent Tasks
+Step 4/15: Generate Subagent Prompts
+Step 5/15: Dispatch Gate
+Step 6/15: Dispatch Subagents (after G-11)
+Step 7/15: Collect Results
+Step 8/15: Validate Subagent Reports
+Step 9/15: Stage 1: Spec Compliance Review
+Step 10/15: Stage 2: Code Quality Review
+Step 11/15: Fix Loop
+Step 12/15: Update Implementation Doc
+Step 13/15: Full Test Run
+Step 14/15: Summary
+Step 15/15: Handoff
+```
+```
+
+Also find (lines 93–97, the step-1 completion marker):
+```
+[PROGRESS] Mark Step 1/14 `completed`:
+```
+Step 1/14: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+Replace with:
+```
+[PROGRESS] Mark Step 1/15 `completed`:
+```
+Step 1/15: Load Config [completed]
+Files read: .paadhai.json
+```
+```
+
+**Expected output:** Both edits succeed.
+
+**Verification command:**
+```bash
+grep -c "Step 8/15: Validate Subagent Reports" .claude/skills/dev-parallel/SKILL.md
+```
+
+**Expected verification output:** `1` (the new item appears exactly once in the initial checklist).
+
+---
+
+## Step 7 — Update Step 4 subagent prompt (new rules + report format)
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Tool:** `Edit`
+
+**Find** (exact text, Step 4's rules list, lines 170–176):
+```
+5. **Rules**:
+   - `[READ]` every file before modifying it
+   - `git add <specific-files>` — never `git add -A`
+   - Run `{config.stack.build_cmd}` and `{config.stack.lint_cmd}` after changes
+   - Mark each step as `done` in implementation.md after completion
+6. **Report format**: files changed, build status, lint status, commit SHA
+```
+
+**Replace with:**
+```
+5. **Rules**:
+   - `[READ]` every file before modifying it
+   - `git add <specific-files>` — never `git add -A`
+   - Run `{config.stack.build_cmd}` and `{config.stack.lint_cmd}` after changes
+   - Mark each step as `done` in implementation.md after completion
+   - **Before reporting, run the `[VERIFY]` gate defined in `references/claude-tools.md § [VERIFY] Convention`.** Your report MUST end with a `GATE: PASS` block containing quoted command output for every claim. Reports without this block will be rejected by the orchestrator and re-dispatched.
+6. **Report format**:
+   ```
+   ## Report
+
+   Files changed : <list>
+   Commit SHA    : <sha>
+
+   ## [VERIFY] Gate
+
+   GATE: PASS
+
+   Claims verified:
+   1. Build succeeds
+      Evidence:
+      ```
+      <quoted output of {config.stack.build_cmd}>
+      ```
+   2. Lint clean
+      Evidence:
+      ```
+      <quoted output of {config.stack.lint_cmd}>
+      ```
+   3. Assigned step(s) marked `done` in implementation.md
+      Evidence:
+      ```
+      <quoted grep/read output showing "status: done" for each assigned step>
+      ```
+   ```
+```
+
+**Expected output:** Edit succeeds. Step 4 now has the `[VERIFY]` rule and the new report format.
+
+**Verification command:**
+```bash
+grep -n "\[VERIFY\] gate defined in" .claude/skills/dev-parallel/SKILL.md
+```
+
+**Expected verification output:** One line showing the new rule inside Step 4.
+
+---
+
+## Step 8 — Insert new Step 8 — Validate Subagent Reports
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Tool:** `Edit`
+
+**Find** (exact text — the boundary between old Step 7 closing and old Step 8 opening, lines 248–253):
+```
+[PROGRESS] Mark Step 7/14 `completed`: `Step 7/14: Collect Results [completed]`
+`Results collected`
+
+---
+
+## STEP 8 — Stage 1: Spec Compliance Review
+```
+
+**Replace with:**
+```
+[PROGRESS] Mark Step 7/15 `completed`: `Step 7/15: Collect Results [completed]`
+`Results collected`
+
+---
+
+## STEP 8 — Validate Subagent Reports
+
+[PROGRESS] Mark Step 8/15 `in_progress`: `Step 8/15: Validate Subagent Reports [in_progress]`
+
+Every subagent report MUST pass the `[VERIFY]` structural validation before the orchestrator accepts it. The orchestrator does NOT re-run verification commands — it inspects the report text for evidence produced by the subagent's own gate run (defined in `references/claude-tools.md § [VERIFY] Convention`).
+
+### Validation checks (text inspection, inline — no subagent delegation)
+
+For each subagent report:
+
+1. **Presence** — Does the report contain a `GATE: PASS` block?
+   - If no → **REJECT**: missing gate
+
+2. **Evidence** — For each claim listed under `Claims verified:`, is there a fenced code block containing command output directly beneath it?
+   - If any claim lacks a fenced evidence block → **REJECT**: claim "<X>" has no quoted evidence
+
+3. **Hedging** — Does the report contain any red-flag language (outside of fenced code blocks)?
+   Red flags: `should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`
+   - If any red flag appears in prose → **REJECT**: hedging in "<quoted sentence>"
+
+### On REJECT → verify-only re-dispatch
+
+[DELEGATE][FAST-MODEL] Dispatch a new subagent (same task group), with a narrower prompt:
+
+```
+The previous subagent for group <N> produced a report that failed [VERIFY] validation.
+Reason: <reject reason>
+
+Previous report:
+<quoted bad report>
+
+Your task: verify-only. Do NOT modify code — the work is already committed.
+1. [READ] the files listed in "Files changed" of the previous report
+2. Run {config.stack.build_cmd}, {config.stack.lint_cmd}, and {config.stack.test_cmd} (if applicable) against the current state
+3. Produce a new report with a well-formed GATE: PASS block including quoted command output for every claim
+4. Do NOT use hedging language
+```
+
+### Retry cap + escalation
+
+- **1 retry** per group.
+- If the verify-only re-dispatch ALSO fails validation → stop and escalate to the user:
+
+```
+Subagent for group <N> failed verification twice.
+
+Last report:
+<quoted bad report>
+
+Reject reason: <reason>
+
+Options:
+  retry  — dispatch a third verify-only subagent
+  manual — you fix and re-run the gate yourself
+  abort  — stop dev-parallel, leave work in place
+```
+
+Wait for explicit user choice. Do not proceed without it.
+
+### On all reports PASS
+
+Proceed to Step 9 (Stage 1: Spec Compliance Review).
+
+[PROGRESS] Mark Step 8/15 `completed`: `Step 8/15: Validate Subagent Reports [completed]`
+`All reports passed [VERIFY] validation`
+
+---
+
+## STEP 9 — Stage 1: Spec Compliance Review
+```
+
+**Expected output:** Edit succeeds. A new full STEP 8 section exists between Collect Results and Stage 1 Spec Compliance Review.
+
+**Verification command:**
+```bash
+grep -n "^## STEP " .claude/skills/dev-parallel/SKILL.md
+```
+
+**Expected verification output:** 15 lines, with `## STEP 8 — Validate Subagent Reports` appearing between `## STEP 7` and `## STEP 9 — Stage 1: Spec Compliance Review`.
+
+---
+
+## Step 9 — Renumber old Steps 8–14 to 9–15
+
+**File:** `.claude/skills/dev-parallel/SKILL.md`
+
+**Tool:** `Edit` with `replace_all: true` for every operation below. The `Step N/14: <label>` pattern is globally unique per N because each label differs.
+
+**Context:** After Step 8 of this doc, the only headers/markers that still carry `/14` numbering are:
+- Checklist items in the Step 1 `[PROGRESS]` initialization block (Steps 1–7 with their original numbers, because Step 6 of this doc rewrote the checklist to use `/15`) — wait, Step 6 already handled Steps 1–14 inside the checklist block. The remaining `/14` references are the **per-step `[PROGRESS]` mark calls** scattered through Steps 1–14.
+- Headers `## STEP 9` through `## STEP 14`
+- Internal `[PROGRESS]` markers inside each of those old step bodies
+
+### 9a — Update per-step `[PROGRESS]` mark calls (Steps 1–7; unchanged numbers but `/14` → `/15`)
+
+Apply each as `Edit` with `replace_all: true`:
+
+| Find | Replace |
+|------|---------|
+| `Step 1/14: Load Config` | `Step 1/15: Load Config` |
+| `Step 2/14: Load Implementation Doc` | `Step 2/15: Load Implementation Doc` |
+| `Step 3/14: Group Independent Tasks` | `Step 3/15: Group Independent Tasks` |
+| `Step 4/14: Generate Subagent Prompts` | `Step 4/15: Generate Subagent Prompts` |
+| `Step 5/14: Dispatch Gate` | `Step 5/15: Dispatch Gate` |
+| `Step 6/14: Dispatch Subagents (after G-11)` | `Step 6/15: Dispatch Subagents (after G-11)` |
+| `Step 7/14: Collect Results` | `Step 7/15: Collect Results` |
+
+Note: `Step 1/14: Load Config` was already rewritten in Step 6 (checklist block), but the `[PROGRESS] Mark Step 1/14 \`completed\`` line was also covered in Step 6. For Steps 2–7, the checklist block (Step 6 of this doc) already uses `/15`, but the per-step `[PROGRESS] Mark Step N/14 ...` calls inside Steps 2–7 bodies still say `/14` — that is what this sub-step updates.
+
+### 9b — Update internal `[PROGRESS]` markers in old Steps 8–14 and shift to new numbers
+
+Apply each as `Edit` with `replace_all: true`. Each pattern is unique, so order does not matter:
+
+| Find | Replace |
+|------|---------|
+| `Step 8/14: Stage 1: Spec Compliance Review` | `Step 9/15: Stage 1: Spec Compliance Review` |
+| `Step 9/14: Stage 2: Code Quality Review` | `Step 10/15: Stage 2: Code Quality Review` |
+| `Step 10/14: Fix Loop` | `Step 11/15: Fix Loop` |
+| `Step 11/14: Update Implementation Doc` | `Step 12/15: Update Implementation Doc` |
+| `Step 12/14: Full Test Run` | `Step 13/15: Full Test Run` |
+| `Step 13/14: Summary` | `Step 14/15: Summary` |
+| `Step 14/14: Handoff` | `Step 15/15: Handoff` |
+
+### 9c — Rename step headers
+
+Apply each as `Edit` (single occurrence each — each header is unique):
+
+| Find | Replace |
+|------|---------|
+| `## STEP 9 — Stage 2: Code Quality Review` | `## STEP 10 — Stage 2: Code Quality Review` |
+| `## STEP 10 — Fix Loop` | `## STEP 11 — Fix Loop` |
+| `## STEP 11 — Update Implementation Doc` | `## STEP 12 — Update Implementation Doc` |
+| `## STEP 12 — Full Test Run` | `## STEP 13 — Full Test Run` |
+| `## STEP 13 — Summary` | `## STEP 14 — Summary` |
+| `## STEP 14 — Handoff` | `## STEP 15 — Handoff` |
+
+**Order matters here:** apply in REVERSE numerical order (STEP 14 → STEP 15 first, then STEP 13 → STEP 14, and so on). This prevents a later rename from accidentally matching a header that was just renamed. (Example: renaming `## STEP 9` → `## STEP 10` first would create a collision when the real `## STEP 10` — now displaced — is later renamed to `## STEP 11`.)
+
+Note: `## STEP 8 — Stage 1: Spec Compliance Review` was already renamed to `## STEP 9 — Stage 1: Spec Compliance Review` in Step 8 of this doc (as part of the replacement block). Do not re-rename it here.
+
+**Expected output:** All edits succeed. File no longer contains any `/14` step references, and all step headers are numbered 1–15 with no gaps.
+
+**Verification commands:**
+```bash
+grep -c "Step [0-9]*/14:" .claude/skills/dev-parallel/SKILL.md
+grep -c "Step [0-9]*/15:" .claude/skills/dev-parallel/SKILL.md
+grep -n "^## STEP " .claude/skills/dev-parallel/SKILL.md
+```
+
+**Expected verification output:**
+- First command: `0` (no `/14` markers remain)
+- Second command: ≥ 30 (roughly 2 per step × 15 steps, plus the 15 checklist lines inside Step 1)
+- Third command: exactly 15 lines, numbered `## STEP 1` through `## STEP 15` in order, with no gaps.
+
+---
+
+## Step 10 — Commit 2
+
+**Tool:** `Bash`
+
+**Commands:**
+```bash
+git add .claude/skills/dev-parallel/SKILL.md
+git status
+git commit -m "feat(dev-parallel): add verification gate and subagent report validation
+
+Apply the [VERIFY] gate to dev-parallel per-subagent. Subagents run
+the 5-step gate on their own work and include a GATE: PASS block with
+quoted evidence in their report. A new orchestrator step (Step 8 —
+Validate Subagent Reports) inspects each report for presence, evidence,
+and hedging language; failures trigger a verify-only re-dispatch with
+a 1-retry cap and user escalation.
+
+Two new rationalization prevention rows added. Step count: 14 -> 15.
+
+Refs #13"
+```
+
+**Expected output:** `git status` shows only `.claude/skills/dev-parallel/SKILL.md` staged. Commit succeeds with 1 file changed.
+
+**Verification command:**
+```bash
+git log -2 --oneline
+```
+
+**Expected verification output:** Two most recent commits on this branch, in order:
+```
+<sha2> feat(dev-parallel): add verification gate and subagent report validation
+<sha1> docs(claude-tools): add [VERIFY] marker and convention
+```
+
+---
+
+## Deviations
+
+(empty — fill in if any step deviates from the plan during execution)

--- a/docs/plans/issue-13/implementation.md
+++ b/docs/plans/issue-13/implementation.md
@@ -10,16 +10,16 @@ branch: feature/13-add-verification-gate-dev-parallel
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 1 | Add `[VERIFY]` marker row to claude-tools.md table | pending |
-| 2 | Add `## [VERIFY] Convention` section to claude-tools.md | pending |
-| 3 | Commit 1 — docs(claude-tools) | pending |
-| 4 | Add 2 rationalization rows to dev-parallel | pending |
-| 5 | Update preamble step count 14 → 15 | pending |
-| 6 | Update Step 1 TodoWrite checklist (14 → 15 items) | pending |
-| 7 | Update Step 4 subagent prompt (new rules + report format) | pending |
-| 8 | Insert new Step 8 — Validate Subagent Reports | pending |
-| 9 | Renumber old Steps 8–14 to 9–15 | pending |
-| 10 | Commit 2 — feat(dev-parallel) | pending |
+| 1 | Add `[VERIFY]` marker row to claude-tools.md table | done |
+| 2 | Add `## [VERIFY] Convention` section to claude-tools.md | done |
+| 3 | Commit 1 — docs(claude-tools) | done |
+| 4 | Add 2 rationalization rows to dev-parallel | done |
+| 5 | Update preamble step count 14 → 15 | done |
+| 6 | Update Step 1 TodoWrite checklist (14 → 15 items) | done |
+| 7 | Update Step 4 subagent prompt (new rules + report format) | done |
+| 8 | Insert new Step 8 — Validate Subagent Reports | done |
+| 9 | Renumber old Steps 8–14 to 9–15 | done |
+| 10 | Commit 2 — feat(dev-parallel) | done |
 
 ---
 

--- a/docs/plans/issue-13/plan.md
+++ b/docs/plans/issue-13/plan.md
@@ -1,0 +1,90 @@
+---
+issue: 13
+title: Add verification gate to dev-parallel and document in claude-tools.md
+branch: feature/13-add-verification-gate-dev-parallel
+milestone: v2.2 — Quality Guards
+status: confirmed
+confirmed_at: 2026-04-11
+---
+
+# Plan — Issue #13
+
+## Overview
+Add a 5-step verification gate to `dev-parallel` (applied per-subagent via evidence-bearing reports) and document `[VERIFY]` as a reusable marker + convention in `references/claude-tools.md`.
+
+## Files to Create
+- None.
+
+## Files to Modify
+- `references/claude-tools.md` — add `[VERIFY]` row to marker table + new `## [VERIFY] Convention` section
+- `.claude/skills/dev-parallel/SKILL.md` — update rationalization table, subagent prompt (Step 4), add new Step 8 (Validate Subagent Reports), renumber old Steps 8–14 to 9–15, update preamble `14 steps` → `15 steps`
+
+## Implementation Steps
+
+**Step 1 — Add `[VERIFY]` marker row to `claude-tools.md` table.** Insert between `[PROGRESS]` and the "Subagent Support" section.
+
+**Step 2 — Add `## [VERIFY] Convention` section to `claude-tools.md`.** Sibling to `## [PROGRESS] Convention`. Contains: purpose, the 5 gate steps (IDENTIFY/RUN/READ/VERIFY/CLAIM), red-flag list, PASS format, FAIL format, docs-only edge case. Copy text verbatim from `dev-implement/SKILL.md § VERIFICATION GATE`.
+
+**Step 3 — Commit 1.** `docs(claude-tools): add [VERIFY] marker and convention`
+
+**Step 4 — Add rationalization rows to `dev-parallel/SKILL.md`.** Add 2 new rows to the existing rationalization table:
+- `"Subagent said GATE: PASS, I can trust it without inspecting"` → always inspect for quoted evidence
+- `"One missing claim isn't worth a re-dispatch"` → partial evidence = no evidence
+
+**Step 5 — Update preamble step count.** Change `14 steps` → `15 steps` in both banner displays.
+
+**Step 6 — Update Step 1 TodoWrite checklist.** Change from 14 items to 15 items, insert `Step 8/15: Validate Subagent Reports` after `Step 7/15: Collect Results`, renumber old 8–14 to 9–15.
+
+**Step 7 — Update Step 4 (Generate Subagent Prompts).** Add two new rules to the subagent prompt builder:
+- "Before reporting, run the `[VERIFY]` gate defined in `references/claude-tools.md § [VERIFY] Convention`."
+- "Your report MUST end with a `GATE: PASS` block containing quoted command output for every claim. Reports without this block will be rejected."
+
+Also extend the report format example to include the `GATE: PASS` block shape.
+
+**Step 8 — Insert new Step 8 (Validate Subagent Reports).** Between old Step 7 (Collect Results) and old Step 8 (Stage 1 Spec Compliance Review). Contains:
+- 3 checks (Presence, Evidence, Hedging)
+- Verify-only re-dispatch logic (1 retry cap)
+- Escalation prompt on second failure (`retry / manual / abort`)
+- `[PROGRESS]` markers
+
+**Step 9 — Renumber old Steps 8–14 to 9–15.** Update every `Step N/14` → `Step N/15` and shift numbers. Update the Stage 1 / Stage 2 headers and all `[PROGRESS]` references.
+
+**Step 10 — Commit 2.** `feat(dev-parallel): add verification gate and subagent report validation`
+
+## Test Cases
+- **Happy path:** Subagent report contains `GATE: PASS` + quoted build/lint/test output → validation passes → proceeds to Stage 1 review.
+- **Edge case — docs-only subagent:** Report contains `GATE: PASS` with quoted `Read`/`Grep` output instead of build output → validation passes.
+- **Edge case — missing gate block:** Report says "done" with no `GATE: PASS` block → validation rejects → verify-only re-dispatch.
+- **Edge case — hedging:** Report says "tests should pass" in a claim line → validation rejects → verify-only re-dispatch.
+- **Edge case — missing evidence:** Report has `GATE: PASS` block but one claim lacks a fenced code block → validation rejects.
+- **Error case — second failure:** Verify-only re-dispatch also returns a bad report → escalation prompt shown to user.
+
+(No runtime test stubs — skills are markdown. Verification happens via the dev-plan Step 14 implementation-doc reviewer and PR review.)
+
+## Security Considerations
+> No security-relevant attack surfaces identified for this issue beyond agent-trust considerations already covered by existing Stage 1 / Stage 2 review stages in dev-parallel.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|---------------|
+| AC-1 (gate added to dev-parallel, executed per-subagent before accept) | Step 7 subagent prompt runs `[VERIFY]` gate internally; new Step 8 validates each report before accepting |
+| AC-2 (completion messages must include quoted verification output; reject without) | New Step 8 Check 1 (Presence) + Check 2 (Evidence) in validator |
+| AC-3 (hedging → re-dispatch with explicit verify instruction) | New Step 8 Check 3 (Hedging); verify-only re-dispatch logic with 1 retry cap |
+| AC-4 (`[VERIFY]` reusable pattern in claude-tools.md) | Steps 1–2: add marker row + `## [VERIFY] Convention` section |
+| AC-5 (claude-tools.md documents 5 gate steps and red-flag list) | Step 2: convention section contains full 5-step definition + red-flag list verbatim from FR-06 |
+
+| SRS Ref | Relation |
+|---------|----------|
+| FR-06 AC-2 | = issue AC-1 (gate added to dev-parallel) |
+| FR-06 AC-4 | = issue AC-3 (hedging triggers re-verification) |
+| FR-06 AC-5 | = issue AC-4 (documented in claude-tools.md) |
+
+## Definition of Done
+- [ ] `references/claude-tools.md` contains `[VERIFY]` marker row + `## [VERIFY] Convention` section
+- [ ] `.claude/skills/dev-parallel/SKILL.md` has 15 steps, new Step 8 validator, updated subagent prompt, 2 new rationalization rows
+- [ ] All existing `[PROGRESS]` numbering in dev-parallel is consistent with 15-step layout
+- [ ] 2 commits pushed: `docs(claude-tools): ...` and `feat(dev-parallel): ...`
+- [ ] Implementation-doc reviewer in dev-plan Step 14 returns PASS
+- [ ] No source build/lint/test (project `language: none` in `.paadhai.json`) — verification is read-through + grep
+- [ ] All 5 issue ACs checked

--- a/docs/plans/issue-13/test-plan.md
+++ b/docs/plans/issue-13/test-plan.md
@@ -1,0 +1,107 @@
+---
+issue: 13
+title: Add verification gate to dev-parallel and document in claude-tools.md
+branch: feature/13-add-verification-gate-dev-parallel
+status: approved
+approved_at: 2026-04-11
+---
+
+# Test Plan — Issue #13
+
+## Test Framework
+
+**None (markdown skills project).** `.paadhai.json` → `stack.language: none`. No runtime build/lint/test commands exist. Verification is performed via:
+
+1. **Structural checks** — `Grep` / `Read` assertions against the modified files.
+2. **AC verification matrix** — each AC maps to a specific structural check that proves it.
+3. **Manual review** — verbatim diff of the `[VERIFY]` convention text in `claude-tools.md` against the source of truth in `dev-implement/SKILL.md`.
+4. **Implementation-doc reviewer** (dev-plan Step 14) + PR review (dev-pr) as secondary gates.
+
+No stub files are generated — there is no runtime to stub.
+
+---
+
+## Structural Checks
+
+### A. `references/claude-tools.md`
+
+| # | Check | Command | Expected |
+|---|-------|---------|----------|
+| A1 | `[VERIFY]` marker row exists in the main marker table | `Grep "^\| \`\[VERIFY\]\`"` in `references/claude-tools.md` | 1 match |
+| A2 | `[VERIFY]` row sits between `[PROGRESS]` and the `Subagent Support` section | `Read` lines around the insertion point | `[VERIFY]` appears after `[PROGRESS]` and before `Subagent Support` header |
+| A3 | `## [VERIFY] Convention` section exists | `Grep "^## \[VERIFY\] Convention"` | 1 match |
+| A4 | Convention section contains all 5 gate steps | `Grep "IDENTIFY"`, `"RUN"`, `"READ"`, `"VERIFY"`, `"CLAIM"` scoped to `claude-tools.md` | all 5 present |
+| A5 | Convention section contains red-flag list | `Grep "Red flags"` in `claude-tools.md` | 1 match |
+| A6 | Convention section contains PASS format block | `Grep "GATE: PASS"` in `claude-tools.md` | ≥1 match |
+| A7 | Convention section contains FAIL format block | `Grep "GATE: FAIL"` in `claude-tools.md` | ≥1 match |
+| A8 | Docs-only edge case documented | `Grep -i "docs-only"` in `claude-tools.md` | ≥1 match |
+
+### B. `.claude/skills/dev-parallel/SKILL.md`
+
+| # | Check | Command | Expected |
+|---|-------|---------|----------|
+| B1 | Preamble shows `15 steps` (not `14 steps`) | `Grep "14 steps"` + `Grep "15 steps"` in `dev-parallel/SKILL.md` | 0 matches for `14 steps`, ≥2 matches for `15 steps` |
+| B2 | TodoWrite checklist has 15 items numbered `Step N/15` | `Grep "Step .*/15:"` in `dev-parallel/SKILL.md` | ≥15 matches |
+| B3 | No stale `Step N/14` references remain | `Grep "Step .*/14"` in `dev-parallel/SKILL.md` | 0 matches |
+| B4 | New `## STEP 8 — Validate Subagent Reports` header exists | `Grep "^## STEP 8 — Validate Subagent Reports"` | 1 match |
+| B5 | Step 8 contains 3 named checks (Presence, Evidence, Hedging) | `Grep "Presence"`, `"Evidence"`, `"Hedging"` scoped to Step 8 | all 3 present |
+| B6 | Step 8 contains verify-only re-dispatch logic with 1-retry cap | `Grep -i "verify-only"` + `Grep "1 retry"` or `"retry cap"` | ≥1 match each |
+| B7 | Step 8 contains escalation prompt (`retry / manual / abort`) | `Grep "retry.*manual.*abort"` | 1 match |
+| B8 | Old Step 14 Handoff renamed to Step 15 | `Grep "^## STEP 15 — Handoff"` | 1 match |
+| B9 | 2 new rationalization rows present | `Grep "trust it without inspecting"` + `Grep "partial evidence"` or `"One missing claim"` | 1 match each |
+| B10 | Step 4 subagent prompt references `[VERIFY]` gate | `Grep "\[VERIFY\]"` in `dev-parallel/SKILL.md` | ≥1 match inside Step 4 block |
+| B11 | Step 4 report format example includes `GATE: PASS` block | `Grep "GATE: PASS"` in `dev-parallel/SKILL.md` | ≥1 match inside Step 4 block |
+| B12 | All `[PROGRESS]` markers use `/15` numbering consistently | `Grep "\[PROGRESS\].*Step .*/"` → count `/15` vs `/14` | all `/15`, zero `/14` |
+
+### C. Cross-file consistency
+
+| # | Check | Method | Expected |
+|---|-------|--------|----------|
+| C1 | `[VERIFY]` convention text in `claude-tools.md` matches the canonical gate in `dev-implement/SKILL.md § VERIFICATION GATE` | Manual read + diff of 5-step definition, red-flag list, PASS/FAIL format | byte-identical semantic content (headings may differ) |
+| C2 | `dev-parallel` Step 4 does NOT duplicate the full gate text — only references it | `Grep -c "IDENTIFY"` in `dev-parallel/SKILL.md` | 0 matches (gate text lives only in `claude-tools.md` and `dev-implement/SKILL.md`) |
+
+---
+
+## AC Verification Matrix
+
+| AC | Requirement | Proven by |
+|----|-------------|-----------|
+| **AC-1** | Gate added to dev-parallel, executed per-subagent before accept | B4 (Step 8 exists) + B10 (subagent prompt runs `[VERIFY]`) + B11 (report format requires `GATE: PASS`) |
+| **AC-2** | Completion messages must include quoted verification output; reject without | B5 (Presence + Evidence checks in Step 8 validator) |
+| **AC-3** | Hedging → re-dispatch with explicit verify instruction | B5 (Hedging check) + B6 (verify-only re-dispatch) + B7 (escalation on 2nd failure) |
+| **AC-4** | `[VERIFY]` reusable pattern in `claude-tools.md` | A1 (marker row) + A2 (placement) + A3 (convention section) |
+| **AC-5** | 5 gate steps + red-flag list documented | A4 (all 5 steps present) + A5 (red-flag list) + A6 (PASS format) + A7 (FAIL format) + C1 (matches canonical source) |
+
+---
+
+## Test Categories Summary
+
+| Category | Count |
+|----------|-------|
+| Structural — claude-tools.md (A1–A8) | 8 |
+| Structural — dev-parallel/SKILL.md (B1–B12) | 12 |
+| Cross-file consistency (C1–C2) | 2 |
+| **Total checks** | **22** |
+
+Mapped to ACs: **5 ACs, 100% covered** (see AC Verification Matrix).
+
+---
+
+## Coverage Target
+
+Not applicable (no runtime code). Coverage is instead defined as:
+
+- **100% of structural checks pass** before merging
+- **100% of ACs have at least one proving check**
+- **Manual review (C1) passes** — `[VERIFY]` convention text is verbatim-equivalent to the canonical gate in `dev-implement/SKILL.md`
+
+---
+
+## How to Execute This Test Plan
+
+During `/paadhai:dev-implement`:
+
+1. The implementation-doc reviewer (dev-plan Step 14 equivalent) already approved the impl doc.
+2. After each impl step, the dev-implement VERIFICATION GATE runs `Read`/`Grep` to verify the step's claim (this test plan supplies the exact commands).
+3. After the final commit, run each check in the tables above as a sanity sweep.
+4. During `/paadhai:dev-pr`, reviewer re-runs C1 manually before approving.

--- a/references/claude-tools.md
+++ b/references/claude-tools.md
@@ -14,6 +14,7 @@ Loaded at session start via `CLAUDE.md`.
 | `[FAST-MODEL]` | `model: "haiku"` parameter on Agent tool | Use fastest available model |
 | `[SMART-MODEL]` | `model: "opus"` parameter on Agent tool | Use most capable model |
 | `[PROGRESS]` | `TodoWrite` tool | Create and update a live step checklist. Graceful degradation: skip if TodoWrite unavailable |
+| `[VERIFY]` | Inline text inspection | Run the 5-step verification gate before claiming a task complete. See `## [VERIFY] Convention` below. |
 
 ## Subagent Support
 
@@ -69,3 +70,68 @@ Build: ✓  Lint: ✓
 ### Graceful degradation
 
 If the TodoWrite tool is unavailable, skip all `[PROGRESS]` calls silently and continue execution. Never block on progress tracking.
+
+## [VERIFY] Convention
+
+`[VERIFY]` marks a mandatory 5-step verification gate that must run before a skill (or subagent) declares a task complete. The gate produces quoted command output as evidence, so a reviewer can confirm the claim without re-running the commands.
+
+**Commands must be re-run every time — results cannot be recalled from memory.** Memory is unreliable; the only acceptable evidence is fresh command output captured during this gate run.
+
+### The 5 steps
+
+1. **IDENTIFY** — What specific claims am I about to make about this task? List each one (e.g., "tests pass", "build succeeds", "file X contains Y").
+2. **RUN** — Execute the verification command(s) for each claim: `{config.stack.build_cmd}`, `{config.stack.lint_cmd}`, `{config.stack.test_cmd}`, or a `Read`/`Grep` for content claims. Do not reuse output from an earlier run.
+3. **READ** — Read the ACTUAL output of each command. Do not summarize from memory. Do not paraphrase.
+4. **VERIFY** — For each claim from IDENTIFY, check the output line-by-line. Does the output literally confirm the claim?
+5. **CLAIM** — Only now may you state the task is complete. Every claim must be followed by a quoted block of the exact output that proves it.
+
+### Red flags — restart the gate from RUN
+
+If your CLAIM message contains any of the following, you MUST restart from step 2 (RUN):
+
+- Hedging words: `should`, `probably`, `seems to`, `I believe`, `appears to`, `looks like`
+- No quoted command output block for a claim
+- Claims without a specific file path + line reference (for content claims)
+- Output quoted from an earlier task or earlier gate run (must be fresh)
+
+### Edge case — docs-only task
+
+If no source files changed, the gate still runs: execute `{config.stack.lint_cmd}` (if available) or the relevant `Read`/`Grep` command to verify the docs claim, and quote that output in CLAIM.
+
+### PASS format
+
+```
+GATE: PASS
+
+Claims verified:
+1. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+2. <claim>
+   Evidence:
+   ```
+   <quoted command output>
+   ```
+```
+
+### FAIL format
+
+If any claim cannot be verified, the gate FAILS and the task stays `pending`. Do not proceed. Do not commit.
+
+```
+GATE: FAIL
+
+Unmet items:
+1. Claim "<claim>" — <reason, e.g., "no output quoted", "output shows 2 failures", "hedging language used">
+2. Claim "<claim>" — <reason>
+
+Next action: fix the missing evidence above and re-run the gate from step 2 (RUN).
+```
+
+### Usage across skills
+
+- **`dev-implement`** applies the gate per-step inside its implementation loop (§ VERIFICATION GATE in that skill's SKILL.md).
+- **`dev-parallel`** requires each subagent to run the gate on its own work and include the PASS block in its report. The orchestrator validates the report structure (Step 8 of dev-parallel) before accepting results.
+- **Future skills** may reference this convention by writing `[VERIFY] Run the gate before declaring <task> complete` in the relevant step.


### PR DESCRIPTION
## Summary

- Add the 5-step `[VERIFY]` gate to `dev-parallel`: each subagent runs the gate on its own work and must include a `GATE: PASS` block with quoted command output in its report.
- Add a new **Step 8 — Validate Subagent Reports** to the orchestrator that inspects each report for presence, evidence, and hedging language — failures trigger a verify-only re-dispatch with a 1-retry cap and user escalation.
- Promote `[VERIFY]` to a first-class reusable pattern in `references/claude-tools.md` (new marker row + full `## [VERIFY] Convention` section) so future skills can adopt it with one reference.
- Raise `dev-parallel` from 14 to 15 steps and add two new rationalization-prevention rows targeting "trust without inspecting" and "partial evidence" failure modes.

## Changes

- `references/claude-tools.md` — added `[VERIFY]` marker row + `## [VERIFY] Convention` section (5 gate steps, red-flag list, PASS/FAIL formats, cross-skill usage notes)
- `.claude/skills/dev-parallel/SKILL.md` — preamble 14→15, TodoWrite checklist +1 item, 2 new rationalization rows, Step 4 subagent-prompt rules+report format updated, new Step 8 (Validate Subagent Reports), Steps 8–14 renumbered to 9–15
- `docs/plans/issue-13/plan.md` — plan with 5 ACs and 10 impl steps
- `docs/plans/issue-13/implementation.md` — 10-step implementation doc, all marked done
- `docs/plans/issue-13/test-plan.md` — 22 structural checks (8 claude-tools + 12 dev-parallel + 2 cross-file) covering all 5 ACs

## Test Plan

Markdown-only skill changes (project `language: none`) — verification is structural, via `Grep`/`Read`. All 22 checks in `docs/plans/issue-13/test-plan.md` are exercised inline by the per-step `[VERIFY]` gates in `/dev-implement`. Reviewer sanity sweep:

- [ ] `grep -n '\[VERIFY\]' references/claude-tools.md` — row present + convention section
- [ ] `grep -c '^## STEP ' .claude/skills/dev-parallel/SKILL.md` → `15`
- [ ] `grep -c 'Step [0-9]*/14' .claude/skills/dev-parallel/SKILL.md` → `0`
- [ ] `grep -n '^## STEP 8 — Validate Subagent Reports' .claude/skills/dev-parallel/SKILL.md` → 1 match
- [ ] `[VERIFY] Convention` text in `claude-tools.md` matches the canonical gate definition in `.claude/skills/dev-implement/SKILL.md § VERIFICATION GATE` (manual diff, C1)
- [ ] Step 4 subagent prompt requires `GATE: PASS` block; Step 8 validator covers Presence/Evidence/Hedging + 1-retry + escalation

## Acceptance Criteria

- [x] AC-1: 5-step gate added to `dev-parallel`, executed per-subagent before accept (Step 4 subagent prompt + Step 8 orchestrator validator)
- [x] AC-2: Completion messages must include quoted verification output; orchestrator rejects if absent (Step 8 Presence + Evidence checks)
- [x] AC-3: Hedging → re-dispatch with explicit verify instruction (Step 8 Hedging check + verify-only re-dispatch prompt)
- [x] AC-4: `[VERIFY]` documented as reusable pattern in `references/claude-tools.md` (marker row + convention section)
- [x] AC-5: 5 gate steps + red-flag list documented in `claude-tools.md` (verbatim from dev-implement canonical gate)

## Notes

- **Architecture (Option C):** subagent runs commands; orchestrator validates report text only. Minimises token usage while keeping validation reliable.
- **Verify-only re-dispatch:** new subagent reads committed files and re-runs commands without modifying code — work already exists, only evidence is regenerated.
- **Retry cap:** 1 retry per group; second failure escalates to user with `retry / manual / abort` options.
- **Source of truth:** canonical gate text lives in `claude-tools.md § [VERIFY] Convention`; `dev-parallel` references it rather than duplicating, so future skill edits only need to touch one file.
- Depends on #12 (verification gate in `dev-implement`, merged via PR #22) — that PR established the canonical 5-step gate text this PR promotes.
- Refs SRS FR-06 AC-2 (= issue AC-1), AC-4 (= issue AC-3), AC-5 (= issue AC-4).

Closes #13