### PR TITLE
feat(dev-implement): add 3-option commit mode selection prompt (#14)

### DIFF
--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dev-implement
-description: Use when implementing confirmed plans — execute steps with code review, auto-commit, and subagent delegation for independent tasks
+description: Use when implementing confirmed plans — execute steps with code review, commit mode selection, and subagent delegation for independent tasks
 ---
 
 # dev-implement: Execute Implementation
 
-Execute the implementation doc step-by-step with code review, auto-commit, and optional subagent delegation.
+Execute the implementation doc step-by-step with code review, commit mode selection, and optional subagent delegation.
 
 ---
 

--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -318,7 +318,7 @@ Lint          : ✓ / ✗
 Code review   : PASS / SKIP
 ```
 
-**G-06**: If auto-commit = yes → commit automatically. If no → wait for "yes".
+**G-06**: If `commit_mode = per-step` → wait for user approval before committing. If `commit_mode = auto-commit` → commit automatically (logic in #15). If `commit_mode = batch` → defer to batch grouping logic (logic in #16).
 
 ### 7g — Commit
 [SHELL] Commit specific files (not `git add -A`):

--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -184,7 +184,21 @@ Doc path  : docs/plans/issue-<n>/implementation.md
 
 Ask user:
 - Model preference? (fast / smart / auto)
-- Auto-commit after each step? (yes / no)
+
+Present commit mode selection using AskUserQuestion:
+
+**Prompt text:** "Implementation has <total step count> steps. How would you like to handle commits?"
+
+**Options:**
+| Label | Description |
+|-------|-------------|
+| Per-step (Recommended) | Approve each commit individually (current behavior) |
+| Auto-commit | Commit automatically after each passing step |
+| Batch | Commit at natural checkpoints (after related groups) |
+
+Store the selection as `commit_mode` (`per-step` | `auto-commit` | `batch`) for use by G-06 and downstream commit logic.
+
+The total step count is derived from the implementation doc's progress table (count of rows excluding the header).
 
 [PROGRESS] Mark Step 2/10 `completed`: `Step 2/10: Load Implementation Doc [completed]`
 `Files read: docs/plans/issue-<n>/implementation.md, docs/plans/issue-<n>/plan.md`

--- a/docs/plans/issue-14/implementation.md
+++ b/docs/plans/issue-14/implementation.md
@@ -11,7 +11,7 @@ status: pending
 |------|-------------|--------|
 | 1 | Replace binary auto-commit question with commit mode prompt | done |
 | 2 | Update G-06 gate wording | done |
-| 3 | Update skill description lines | pending |
+| 3 | Update skill description lines | done |
 | 4 | Verify internal consistency | pending |
 | 5 | Commit changes | pending |
 

--- a/docs/plans/issue-14/implementation.md
+++ b/docs/plans/issue-14/implementation.md
@@ -2,7 +2,7 @@
 issue: 14
 title: Add commit mode selection prompt to dev-implement
 branch: feature/14-commit-mode-selection-prompt
-status: pending
+status: done
 ---
 
 ## Progress
@@ -13,7 +13,7 @@ status: pending
 | 2 | Update G-06 gate wording | done |
 | 3 | Update skill description lines | done |
 | 4 | Verify internal consistency | done |
-| 5 | Commit changes | pending |
+| 5 | Commit changes | done |
 
 ---
 

--- a/docs/plans/issue-14/implementation.md
+++ b/docs/plans/issue-14/implementation.md
@@ -10,7 +10,7 @@ status: pending
 | Step | Description | Status |
 |------|-------------|--------|
 | 1 | Replace binary auto-commit question with commit mode prompt | done |
-| 2 | Update G-06 gate wording | pending |
+| 2 | Update G-06 gate wording | done |
 | 3 | Update skill description lines | pending |
 | 4 | Verify internal consistency | pending |
 | 5 | Commit changes | pending |

--- a/docs/plans/issue-14/implementation.md
+++ b/docs/plans/issue-14/implementation.md
@@ -1,0 +1,154 @@
+---
+issue: 14
+title: Add commit mode selection prompt to dev-implement
+branch: feature/14-commit-mode-selection-prompt
+status: pending
+---
+
+## Progress
+
+| Step | Description | Status |
+|------|-------------|--------|
+| 1 | Replace binary auto-commit question with commit mode prompt | pending |
+| 2 | Update G-06 gate wording | pending |
+| 3 | Update skill description lines | pending |
+| 4 | Verify internal consistency | pending |
+| 5 | Commit changes | pending |
+
+---
+
+## Step 1 — Replace binary auto-commit question with commit mode prompt
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+**Location:** Lines 185–187 (inside STEP 2 — Load Implementation Doc)
+
+**Current text (exact):**
+```
+Ask user:
+- Model preference? (fast / smart / auto)
+- Auto-commit after each step? (yes / no)
+```
+
+**Replace with:**
+```
+Ask user:
+- Model preference? (fast / smart / auto)
+
+Present commit mode selection using AskUserQuestion:
+
+**Prompt text:** "Implementation has <total step count> steps. How would you like to handle commits?"
+
+**Options:**
+| Label | Description |
+|-------|-------------|
+| Per-step (Recommended) | Approve each commit individually (current behavior) |
+| Auto-commit | Commit automatically after each passing step |
+| Batch | Commit at natural checkpoints (after related groups) |
+
+Store the selection as `commit_mode` (`per-step` | `auto-commit` | `batch`) for use by G-06 and downstream commit logic.
+
+The total step count is derived from the implementation doc's progress table (count of rows excluding the header).
+```
+
+**Expected outcome:** After loading the implementation doc, `dev-implement` presents a 3-option commit mode selection with the step count, instead of a binary yes/no.
+
+---
+
+## Step 2 — Update G-06 gate wording
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+**Location:** Line 307 (inside Step 7f — Step Summary + Gate)
+
+**Current text (exact):**
+```
+**G-06**: If auto-commit = yes → commit automatically. If no → wait for "yes".
+```
+
+**Replace with:**
+```
+**G-06**: If `commit_mode = per-step` → wait for user approval before committing. If `commit_mode = auto-commit` → commit automatically (logic in #15). If `commit_mode = batch` → defer to batch grouping logic (logic in #16).
+```
+
+**Expected outcome:** G-06 references the 3-state `commit_mode` variable, keeping the doc internally consistent with the new prompt.
+
+---
+
+## Step 3 — Update skill description lines
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+
+The following lines reference "auto-commit" in the skill description. These are informational and should be updated to reflect the new commit mode selection:
+
+**Line 3 — current text (exact):**
+```
+description: Use when implementing confirmed plans — execute steps with code review, auto-commit, and subagent delegation for independent tasks
+```
+
+**Replace with:**
+```
+description: Use when implementing confirmed plans — execute steps with code review, commit mode selection, and subagent delegation for independent tasks
+```
+
+**Line 8 — current text (exact):**
+```
+Execute the implementation doc step-by-step with code review, auto-commit, and optional subagent delegation.
+```
+
+**Replace with:**
+```
+Execute the implementation doc step-by-step with code review, commit mode selection, and optional subagent delegation.
+```
+
+**Expected outcome:** Skill description reflects the new 3-option commit mode instead of "auto-commit".
+
+---
+
+## Step 4 — Verify internal consistency
+
+**Commands:**
+```bash
+grep -n "auto-commit" .claude/skills/dev-implement/SKILL.md
+grep -n "Auto-commit" .claude/skills/dev-implement/SKILL.md
+```
+
+**Expected outcome — allowed references (4 total):**
+
+| Line (approx) | Context | Why it's OK |
+|----------------|---------|-------------|
+| ~40 (new prompt) | "Auto-commit" option label | New commit mode prompt option |
+| ~40 (new prompt) | `commit_mode = auto-commit` | Variable value in prompt description |
+| ~64 | Rationalization table: "I'll commit these steps together" | Deferred to #16 — do not modify |
+| ~307 (new G-06) | `commit_mode = auto-commit` | G-06 gate condition |
+
+**Forbidden references (must be zero):**
+- `auto-commit = yes`
+- `auto-commit = no`
+- `Auto-commit after each step? (yes / no)`
+
+If any forbidden reference is found, identify the exact line and text and replace it.
+
+**Expected outcome:** Zero forbidden references. All remaining "auto-commit" occurrences are in the allowed list above.
+
+---
+
+## Step 5 — Commit changes
+
+**Commands:**
+```bash
+git add .claude/skills/dev-implement/SKILL.md
+git commit -m "feat(dev-implement): replace binary auto-commit with 3-option commit mode prompt
+
+Add commit mode selection (per-step, auto-commit, batch) with step count
+to STEP 2 of dev-implement. Update G-06 gate to reference commit_mode
+variable. Update skill description lines.
+
+Refs #14"
+```
+
+**Expected outcome:** Clean commit with only `.claude/skills/dev-implement/SKILL.md` changed.
+
+---
+
+## Deviations
+
+(none)

--- a/docs/plans/issue-14/implementation.md
+++ b/docs/plans/issue-14/implementation.md
@@ -9,7 +9,7 @@ status: pending
 
 | Step | Description | Status |
 |------|-------------|--------|
-| 1 | Replace binary auto-commit question with commit mode prompt | pending |
+| 1 | Replace binary auto-commit question with commit mode prompt | done |
 | 2 | Update G-06 gate wording | pending |
 | 3 | Update skill description lines | pending |
 | 4 | Verify internal consistency | pending |

--- a/docs/plans/issue-14/implementation.md
+++ b/docs/plans/issue-14/implementation.md
@@ -12,7 +12,7 @@ status: pending
 | 1 | Replace binary auto-commit question with commit mode prompt | done |
 | 2 | Update G-06 gate wording | done |
 | 3 | Update skill description lines | done |
-| 4 | Verify internal consistency | pending |
+| 4 | Verify internal consistency | done |
 | 5 | Commit changes | pending |
 
 ---
@@ -151,4 +151,5 @@ Refs #14"
 
 ## Deviations
 
-(none)
+- **Commit cadence**: Implementation committed per-step (auto-commit mode selected by user) instead of a single final commit at Step 5. The doc's Step 5 commit block therefore became a summary/no-op rather than a grouping commit.
+- **Allowed reference count**: The doc predicted 4 allowed `auto-commit` references post-edit; actual grep found 3. The 4th row in the doc's table ("I'll commit these steps together") is wording in the rationalization table that does not contain the literal `auto-commit` substring, so it does not show up in a grep for that term. Left unmodified as the doc instructed.

--- a/docs/plans/issue-14/plan.md
+++ b/docs/plans/issue-14/plan.md
@@ -1,0 +1,82 @@
+---
+issue: 14
+title: Add commit mode selection prompt to dev-implement
+branch: feature/14-commit-mode-selection-prompt
+milestone: v2.3 — Workflow Efficiency
+status: confirmed
+confirmed_at: 2026-04-13T00:00:00Z
+---
+
+## Overview
+
+Replace the binary "Auto-commit after each step? (yes/no)" prompt in `dev-implement` Step 2 with a 3-option commit mode selection prompt (per-step, auto-commit, batch) that includes the total step count. Update G-06 wording to reference the new `commit_mode` variable.
+
+## Files to Create
+
+- `docs/plans/issue-14/plan.md`: Confirmed plan document
+- `docs/plans/issue-14/implementation.md`: Step-by-step implementation doc
+
+## Files to Modify
+
+- `.claude/skills/dev-implement/SKILL.md`: Replace binary auto-commit question with 3-option commit mode prompt (Step 2) and update G-06 wording (Step 7f)
+
+## Implementation Steps
+
+1. **Replace binary auto-commit question with commit mode prompt (Step 2, lines 185-187)**
+   - Remove: `Auto-commit after each step? (yes / no)`
+   - Add: AskUserQuestion-based 3-option prompt with step count
+   - Include prompt text: "Implementation has N steps. How would you like to handle commits?"
+   - Options: Per-step (current behavior), Auto-commit, Batch
+   - Store selection as `commit_mode` variable (`per-step` | `auto-commit` | `batch`)
+   - Expected: Step 2 now presents 3-option commit mode selection after loading the implementation doc
+
+2. **Update G-06 gate wording (Step 7f, line 307)**
+   - Remove: `If auto-commit = yes → commit automatically. If no → wait for "yes".`
+   - Add: `If commit_mode = per-step → wait for user approval. If commit_mode = auto-commit → commit automatically. If commit_mode = batch → defer to batch logic.`
+   - Expected: G-06 references the 3-state `commit_mode` variable
+
+3. **Verify internal consistency**
+   - Grep `SKILL.md` for any remaining references to `auto-commit = yes` or the old binary pattern
+   - Ensure no orphaned references to the old yes/no variable
+   - Expected: Zero stale references
+
+## Test Cases
+
+- **Happy path**: Load a 10-step implementation plan — verify prompt appears showing all 3 modes and the step count
+- **Edge case**: Single-step plan — verify prompt still appears
+- **Invalid input**: AskUserQuestion constrains selection — invalid input structurally impossible
+
+## Security Considerations
+
+No security-relevant attack surfaces identified for this issue.
+
+SRS security note for downstream issues: SRS 6.2 requires "auto-commit mode must not bypass pre-commit hooks (`--no-verify` is never used)" — applies to #15, not #14.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|--------------|
+| AC-1 | Prompt placed in Step 2, after loading implementation doc, before step execution (Step 3+) |
+| AC-2 | AskUserQuestion presents all 3 options: per-step, auto-commit, batch |
+| AC-3 | Per-step option described as "approve each commit individually (current behavior)" — G-06 preserves gate |
+| AC-4 | Selection stored as `commit_mode` variable, referenced by G-06 for use by #15/#16 |
+| AC-5 | Prompt text includes total step count parsed from implementation doc progress table |
+
+## Definition of Done
+
+- [ ] All ACs checked
+- [ ] `SKILL.md` internally consistent — no stale references to old binary auto-commit
+- [ ] G-06 references `commit_mode` with all 3 states
+- [ ] SRS FR-04 AC-1, AC-2 satisfied (AC-3/4/5 deferred to #15/#16)
+
+## Brainstorming Decisions
+
+| Question | Decision | SRS Ref |
+|----------|----------|---------|
+| Prompt style | Replace auto-commit only, keep model preference separate | FR-04 |
+| Persistence | In-memory only, no session file | Q-02 (Open) |
+| G-06 update | Update wording to reference commit_mode (3 states) | FR-04 AC-2 |
+| Rationalization table | Defer update to #16 | FR-05 |
+| Prompt mechanism | AskUserQuestion tool | FR-04 content spec |
+| Step count source | Parse implementation doc progress table | FR-04 AC-1 |
+| Invalid input | Handled by AskUserQuestion constraints | Issue test checklist |


### PR DESCRIPTION
## Summary

- Replaces the binary `Auto-commit after each step? (yes/no)` question in `dev-implement` STEP 2 with a 3-option AskUserQuestion prompt: Per-step (Recommended), Auto-commit, Batch.
- Prompt text includes the total step count parsed from the implementation doc's progress table.
- Selection is stored as `commit_mode` (`per-step` | `auto-commit` | `batch`) for use by G-06 and downstream commit logic.
- G-06 gate (Step 7f) rewritten to route on `commit_mode` — auto-commit and batch logic are deferred to #15 and #16 respectively.
- Frontmatter `description` and intro line updated to reflect "commit mode selection" instead of "auto-commit".

## Changes

- `.claude/skills/dev-implement/SKILL.md` — prompt block (STEP 2), G-06 wording (Step 7f), description and intro line.
- `docs/plans/issue-14/plan.md` — confirmed plan doc.
- `docs/plans/issue-14/implementation.md` — step-by-step implementation doc (all 5 steps marked done).

## Test Plan

No build/lint/test stack configured for this docs-only repo (`.paadhai.json` has empty `build_cmd`/`lint_cmd`/`test_cmd`). Verification performed via grep + Read:

- [x] `grep "Auto-commit after each step? (yes / no)"` → no matches (old prompt removed)
- [x] `grep "auto-commit = (yes|no)"` → no matches (old G-06 wording removed)
- [x] `grep -i "auto-commit"` → 3 matches, all in allowed locations (prompt option label, `commit_mode` variable values, G-06 gate)
- [x] New prompt block present at `SKILL.md:185-201` with AskUserQuestion, all 3 options, and `commit_mode` variable
- [x] G-06 at `SKILL.md:321` references all 3 `commit_mode` states
- [x] Skill description (`SKILL.md:3`) and intro (`SKILL.md:8`) updated

## Acceptance Criteria

- [x] AC-1: Prompt placed in STEP 2, after loading implementation doc, before step execution
- [x] AC-2: Prompt presents all 3 options: per-step, auto-commit, batch
- [x] AC-3: Per-step option described as "approve each commit individually (current behavior)"; G-06 preserves the gate
- [x] AC-4: Selection stored as `commit_mode` variable, referenced by G-06 for use by #15/#16
- [x] AC-5: Prompt text includes total step count derived from the implementation doc's progress table

## Notes

- Uses `AskUserQuestion` (harness-provided) rather than free-text input, so "invalid choice" is structurally impossible (AC covered without extra retry logic).
- Auto-commit and batch **logic** remain deferred: AC-5 from the implementation plan (auto-commit behavior) lives in #15; batch grouping lives in #16. This PR only wires the prompt + variable.
- Implementation was committed per-step under `auto-commit` mode (selected during dev-implement) rather than a single bundled commit; noted in `implementation.md` deviations.

Closes #14