### PR TITLE
feat(dev-implement): implement auto-commit logic with failure revert (#15)

### DIFF
--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -318,7 +318,22 @@ Lint          : ✓ / ✗
 Code review   : PASS / SKIP
 ```
 
-**G-06**: If `commit_mode = per-step` → wait for user approval before committing. If `commit_mode = auto-commit` → commit automatically (logic in #15). If `commit_mode = batch` → defer to batch grouping logic (logic in #16).
+**G-06** branches on `commit_mode`:
+
+- **`per-step`** → wait for explicit user approval before committing (unchanged).
+- **`auto-commit` — pass path** → if build (7d), lint (7d), code review (7c), and verification gate (7d.1) all PASS, commit automatically using 7g with no approval prompt. Unconfigured check commands (empty `{config.stack.build_cmd}` or `{config.stack.lint_cmd}`) are treated as non-blocking: the matching check is skipped, not failed.
+- **`auto-commit` — fail path** → on any FAIL (build, lint, code review, or verification gate), do **not** commit. Flip `commit_mode` from `auto-commit` to `per-step` for the remainder of the session, display the MODE SWITCH banner below, then fall through to per-step G-06 for this failing step once the developer has fixed the issue and re-run the relevant gates. Once flipped, `commit_mode` stays `per-step` for every subsequent step in this session — it does not flip back.
+- **`batch`** → defer to batch grouping logic (logic in #16); unchanged.
+
+MODE SWITCH banner (displayed on `auto-commit` fail path, immediately before per-step G-06 re-engages):
+
+```
+────────────────────────────────────────
+MODE SWITCH: auto-commit → per-step
+Reason: <build | lint | review | gate> failed on step <N>
+All remaining steps will use per-step approval.
+────────────────────────────────────────
+```
 
 ### 7g — Commit
 [SHELL] Commit specific files (not `git add -A`):

--- a/.claude/skills/dev-implement/SKILL.md
+++ b/.claude/skills/dev-implement/SKILL.md
@@ -359,6 +359,8 @@ Commit type guide:
 
 Subject: max 72 chars, imperative mood ("add X" not "added X").
 
+Auto-commit uses the same `git commit` invocation as per-step — `--no-verify` is never used. If a pre-commit hook fails, treat it as a step failure: the commit aborts, the MODE SWITCH banner displays with reason `hook`, `commit_mode` flips to `per-step`, and G-06 re-engages for the failing step.
+
 ### 7h — Progress Dashboard
 After each step's commit, display a compact aggregate progress dashboard. Data MUST come from actual command output — never estimate or fabricate values.
 

--- a/docs/plans/issue-15/implementation.md
+++ b/docs/plans/issue-15/implementation.md
@@ -14,7 +14,7 @@ status: pending
 | 1    | Expand G-06 prose at Step 7f with full auto-commit semantics | done    |
 | 2    | Add `--no-verify` safeguard paragraph at end of Step 7g      | done    |
 | 3    | Verify internal consistency (grep assertions)                | done    |
-| 4    | Commit changes                                               | pending |
+| 4    | Commit changes                                               | done    |
 
 ---
 
@@ -143,3 +143,4 @@ Refs #15"
 ## Deviations
 
 - **Step 3 grep #2 (MODE SWITCH count)**: Plan predicted "exactly 1" occurrence of the substring `MODE SWITCH` inside 7f. Actual result: 4 total occurrences (3 prose references in 7f + 1 in the new 7g safeguard paragraph added by Step 2). The *banner literal line* (`MODE SWITCH: auto-commit → per-step`) does appear exactly once at line 332, which is the semantically meaningful check. The plan's stated count was overly strict given that the 7g safeguard paragraph unavoidably names the banner to describe hook-failure behavior. Interpreting the intent (banner literal uniqueness) rather than the literal count — the gate PASSES.
+- **Step 4 (commit cadence)**: Implementation ran in `auto-commit` mode, so Steps 1–3 each produced their own commit as they passed the verification gate. Step 4's "single bundling commit" therefore became a summary/no-op. This is consistent with the note under Step 4 in the implementation doc.

--- a/docs/plans/issue-15/implementation.md
+++ b/docs/plans/issue-15/implementation.md
@@ -13,7 +13,7 @@ status: pending
 |------|--------------------------------------------------------------|---------|
 | 1    | Expand G-06 prose at Step 7f with full auto-commit semantics | done    |
 | 2    | Add `--no-verify` safeguard paragraph at end of Step 7g      | done    |
-| 3    | Verify internal consistency (grep assertions)                | pending |
+| 3    | Verify internal consistency (grep assertions)                | done    |
 | 4    | Commit changes                                               | pending |
 
 ---
@@ -142,4 +142,4 @@ Refs #15"
 
 ## Deviations
 
-(None yet — populated during execution.)
+- **Step 3 grep #2 (MODE SWITCH count)**: Plan predicted "exactly 1" occurrence of the substring `MODE SWITCH` inside 7f. Actual result: 4 total occurrences (3 prose references in 7f + 1 in the new 7g safeguard paragraph added by Step 2). The *banner literal line* (`MODE SWITCH: auto-commit → per-step`) does appear exactly once at line 332, which is the semantically meaningful check. The plan's stated count was overly strict given that the 7g safeguard paragraph unavoidably names the banner to describe hook-failure behavior. Interpreting the intent (banner literal uniqueness) rather than the literal count — the gate PASSES.

--- a/docs/plans/issue-15/implementation.md
+++ b/docs/plans/issue-15/implementation.md
@@ -12,7 +12,7 @@ status: pending
 | Step | Description                                                  | Status  |
 |------|--------------------------------------------------------------|---------|
 | 1    | Expand G-06 prose at Step 7f with full auto-commit semantics | done    |
-| 2    | Add `--no-verify` safeguard paragraph at end of Step 7g      | pending |
+| 2    | Add `--no-verify` safeguard paragraph at end of Step 7g      | done    |
 | 3    | Verify internal consistency (grep assertions)                | pending |
 | 4    | Commit changes                                               | pending |
 

--- a/docs/plans/issue-15/implementation.md
+++ b/docs/plans/issue-15/implementation.md
@@ -11,7 +11,7 @@ status: pending
 
 | Step | Description                                                  | Status  |
 |------|--------------------------------------------------------------|---------|
-| 1    | Expand G-06 prose at Step 7f with full auto-commit semantics | pending |
+| 1    | Expand G-06 prose at Step 7f with full auto-commit semantics | done    |
 | 2    | Add `--no-verify` safeguard paragraph at end of Step 7g      | pending |
 | 3    | Verify internal consistency (grep assertions)                | pending |
 | 4    | Commit changes                                               | pending |

--- a/docs/plans/issue-15/implementation.md
+++ b/docs/plans/issue-15/implementation.md
@@ -1,0 +1,145 @@
+---
+issue: 15
+title: Implement auto-commit logic with failure revert in dev-implement
+branch: feature/15-auto-commit-failure-revert
+status: pending
+---
+
+# Implementation Doc — Issue #15
+
+## Progress
+
+| Step | Description                                                  | Status  |
+|------|--------------------------------------------------------------|---------|
+| 1    | Expand G-06 prose at Step 7f with full auto-commit semantics | pending |
+| 2    | Add `--no-verify` safeguard paragraph at end of Step 7g      | pending |
+| 3    | Verify internal consistency (grep assertions)                | pending |
+| 4    | Commit changes                                               | pending |
+
+---
+
+## Step 1 — Expand G-06 prose at Step 7f with full auto-commit semantics
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+**Location:** Line 321 (inside `### 7f — Step Summary + Gate`)
+**Tool:** `Edit`
+
+**Current text (exact `old_string`):**
+```
+**G-06**: If `commit_mode = per-step` → wait for user approval before committing. If `commit_mode = auto-commit` → commit automatically (logic in #15). If `commit_mode = batch` → defer to batch grouping logic (logic in #16).
+```
+
+**Replace with (exact `new_string`):**
+```
+**G-06** branches on `commit_mode`:
+
+- **`per-step`** → wait for explicit user approval before committing (unchanged).
+- **`auto-commit` — pass path** → if build (7d), lint (7d), code review (7c), and verification gate (7d.1) all PASS, commit automatically using 7g with no approval prompt. Unconfigured check commands (empty `{config.stack.build_cmd}` or `{config.stack.lint_cmd}`) are treated as non-blocking: the matching check is skipped, not failed.
+- **`auto-commit` — fail path** → on any FAIL (build, lint, code review, or verification gate), do **not** commit. Flip `commit_mode` from `auto-commit` to `per-step` for the remainder of the session, display the MODE SWITCH banner below, then fall through to per-step G-06 for this failing step once the developer has fixed the issue and re-run the relevant gates. Once flipped, `commit_mode` stays `per-step` for every subsequent step in this session — it does not flip back.
+- **`batch`** → defer to batch grouping logic (logic in #16); unchanged.
+
+MODE SWITCH banner (displayed on `auto-commit` fail path, immediately before per-step G-06 re-engages):
+
+```
+────────────────────────────────────────
+MODE SWITCH: auto-commit → per-step
+Reason: <build | lint | review | gate> failed on step <N>
+All remaining steps will use per-step approval.
+────────────────────────────────────────
+```
+```
+
+**Expected outcome:** G-06 section describes all 3 modes in bullet form; `(logic in #15)` placeholder removed; MODE SWITCH banner present verbatim.
+
+---
+
+## Step 2 — Add `--no-verify` safeguard paragraph at end of Step 7g
+
+**File:** `.claude/skills/dev-implement/SKILL.md`
+**Location:** Between line 345 (`Subject: max 72 chars, imperative mood ("add X" not "added X").`) and line 347 (`### 7h — Progress Dashboard`)
+**Tool:** `Edit`
+
+**Current text (exact `old_string`):**
+```
+Subject: max 72 chars, imperative mood ("add X" not "added X").
+
+### 7h — Progress Dashboard
+```
+
+**Replace with (exact `new_string`):**
+```
+Subject: max 72 chars, imperative mood ("add X" not "added X").
+
+Auto-commit uses the same `git commit` invocation as per-step — `--no-verify` is never used. If a pre-commit hook fails, treat it as a step failure: the commit aborts, the MODE SWITCH banner displays with reason `hook`, `commit_mode` flips to `per-step`, and G-06 re-engages for the failing step.
+
+### 7h — Progress Dashboard
+```
+
+**Expected outcome:** New safeguard paragraph inserted as the final paragraph of 7g, immediately before the `### 7h` heading.
+
+---
+
+## Step 3 — Verify internal consistency
+
+**Tool:** `Grep` + `Bash`
+
+Run each grep and confirm the expected count. Capture the output for the verification gate.
+
+1. **No orphan placeholder:**
+   ```bash
+   grep -n "logic in #15" .claude/skills/dev-implement/SKILL.md
+   ```
+   **Expected output:** empty (zero matches).
+
+2. **MODE SWITCH banner present exactly once:**
+   ```bash
+   grep -cn "MODE SWITCH" .claude/skills/dev-implement/SKILL.md
+   ```
+   **Expected output:** `1` (single line).
+
+3. **`--no-verify` safeguard present exactly once:**
+   ```bash
+   grep -cn "no-verify" .claude/skills/dev-implement/SKILL.md
+   ```
+   **Expected output:** `1` (single line).
+
+4. **`commit_mode` still referenced in STEP 2 and 7f:**
+   ```bash
+   grep -n "commit_mode" .claude/skills/dev-implement/SKILL.md
+   ```
+   **Expected output:** at least four lines — one in STEP 2 (`Store the selection as ... commit_mode ...`), and three in the expanded G-06 block (per-step, auto-commit fail path mention, and the "it does not flip back" clause). No references outside STEP 2 or Step 7f.
+
+5. **Placeholder "(logic in #16)" intentionally preserved:**
+   ```bash
+   grep -n "logic in #16" .claude/skills/dev-implement/SKILL.md
+   ```
+   **Expected output:** exactly `1` match (the batch mode line inside the expanded G-06). Issue #16 will remove it.
+
+**Expected outcome:** All five greps match the stated counts. Any mismatch → restart Step 1 or Step 2 edits.
+
+---
+
+## Step 4 — Commit changes
+
+**Commands:**
+```bash
+git add .claude/skills/dev-implement/SKILL.md
+git commit -m "feat(dev-implement): implement auto-commit logic with failure revert
+
+Expand G-06 at Step 7f with full auto-commit semantics: silent commit on
+passing steps; revert to per-step mode with MODE SWITCH banner on any
+build/lint/review/gate failure. Add --no-verify safeguard paragraph at
+Step 7g.
+
+Refs #15"
+```
+
+**Expected outcome:** Single clean commit containing only `.claude/skills/dev-implement/SKILL.md`. The plan and implementation doc under `docs/plans/issue-15/` are committed separately by `/paadhai:dev-plan` (its Step 16), not by this step.
+
+> Note: if `dev-implement` runs this doc in per-step mode, Steps 1–3 may commit individually; in that case this Step 4 becomes a summary/no-op. Document any deviation under the "Deviations" section below.
+
+---
+
+## Deviations
+
+(None yet — populated during execution.)

--- a/docs/plans/issue-15/plan.md
+++ b/docs/plans/issue-15/plan.md
@@ -1,0 +1,117 @@
+---
+issue: 15
+title: Implement auto-commit logic with failure revert in dev-implement
+branch: feature/15-auto-commit-failure-revert
+milestone: v2.3 — Workflow Efficiency
+status: confirmed
+confirmed_at: 2026-04-22
+---
+
+## Overview
+
+Implement the auto-commit mode logic in `.claude/skills/dev-implement/SKILL.md`: when `commit_mode = auto-commit` is selected, commit silently after each passing step (build, lint, code review, and verification gate all PASS). If any of those fail, revert `commit_mode` to `per-step` for the remainder of the session and notify the developer with a MODE SWITCH banner. Option B chosen — extend G-06 prose in place at Step 7f; no renumbering of sub-steps 7g/7h.
+
+## Files to Create
+
+- `docs/plans/issue-15/plan.md` — this plan document
+- `docs/plans/issue-15/implementation.md` — step-by-step implementation doc
+
+## Files to Modify
+
+- `.claude/skills/dev-implement/SKILL.md`:
+  1. Expand the G-06 bullet inside Step 7f to contain full auto-commit semantics (pass path, revert triggers, MODE SWITCH banner, post-revert behavior).
+  2. Add one sentence at the end of Step 7g stating `--no-verify` is never used and that a failing pre-commit hook counts as a step failure.
+
+## Implementation Steps
+
+1. **Expand G-06 prose at Step 7f in `SKILL.md`**
+   - Replace the current one-liner:
+     `**G-06**: If commit_mode = per-step → wait for user approval before committing. If commit_mode = auto-commit → commit automatically (logic in #15). If commit_mode = batch → defer to batch grouping logic (logic in #16).`
+   - With a multi-bullet block describing:
+     - **per-step** → wait for explicit user approval (unchanged).
+     - **auto-commit pass path** → if build, lint, code review (7c), and verification gate (7d.1) all PASS, commit automatically using 7g — no approval prompt. Unconfigured check commands (empty `{config.stack.build_cmd}` or `{config.stack.lint_cmd}`) are treated as non-blocking (matching check is skipped, not failed).
+     - **auto-commit fail path** → on any FAIL (build, lint, review, or verification gate), flip `commit_mode` from `auto-commit` to `per-step` for the remainder of the session, display the MODE SWITCH banner, then fall through to per-step G-06 for this failing step after the fix.
+     - **batch** → unchanged; still defers to #16.
+   - Include the MODE SWITCH banner literal exactly:
+     ```
+     ────────────────────────────────────────
+     MODE SWITCH: auto-commit → per-step
+     Reason: <build | lint | review | gate> failed on step <N>
+     All remaining steps will use per-step approval.
+     ────────────────────────────────────────
+     ```
+   - Expected: G-06 section describes all 3 modes with full auto-commit semantics; placeholder `(logic in #15)` removed.
+
+2. **Add `--no-verify` safeguard under Step 7g**
+   - Insert a single paragraph at the end of 7g, after the commit-type table and subject-line rule:
+     > Auto-commit uses the same `git commit` invocation as per-step — `--no-verify` is never used. If a pre-commit hook fails, treat it as a step failure: the commit aborts, the MODE SWITCH banner displays with reason `hook`, `commit_mode` flips to `per-step`, and G-06 re-engages for the failing step.
+   - Expected: post-edit grep for `--no-verify` returns exactly one occurrence, inside the new paragraph.
+
+3. **Verify internal consistency**
+   - `grep -n "logic in #15" .claude/skills/dev-implement/SKILL.md` → zero matches.
+   - `grep -n "MODE SWITCH" .claude/skills/dev-implement/SKILL.md` → exactly one occurrence, inside Step 7f.
+   - `grep -n "no-verify" .claude/skills/dev-implement/SKILL.md` → exactly one occurrence, inside Step 7g.
+   - `grep -n "commit_mode" .claude/skills/dev-implement/SKILL.md` → original Step 2 occurrence plus expanded 7f references; no orphan references.
+   - Expected: all four greps match the stated counts.
+
+## Test Cases
+
+- **Happy path (AC-1, AC-2)**: A 5-step implementation with `auto-commit` and every step passing 7c + 7d + 7d.1 — prose must describe silent commit via 7g with no approval prompt.
+- **Edge case (AC-3)**: Prose names all four failure sources — build, lint, review, verification gate — as revert triggers, plus pre-commit hook failure via 7g safeguard.
+- **Edge case — empty `build_cmd`**: Prose explicitly states that empty `{config.stack.build_cmd}` / `{config.stack.lint_cmd}` are non-blocking (skipped, not failed).
+- **Error case (AC-4)**: Prose states `commit_mode` flips to `per-step` and "remains per-step for all subsequent steps" (or equivalent) — grep confirms this phrasing.
+- **Verification-gate interaction (Q2)**: Prose names the verification gate (7d.1) as a revert trigger alongside build/lint/review.
+
+## Security Considerations
+
+- Auto-commit uses the same `git add <specific-files>` pattern as per-step; scope unchanged.
+- `--no-verify` explicitly forbidden (SRS §6.2) — enforced by new prose under 7g.
+- Any failure triggers auto-revert to per-step (SRS §6.3) — no silent broken commits.
+- `commit_mode` input is AskUserQuestion-constrained (3 known values); session-local, never persisted to disk.
+- MODE SWITCH banner reason is a fixed category name — no paths, diff content, or credentials.
+
+**Security Checklist:**
+- [ ] `commit_mode` values constrained at entry point.
+- [ ] MODE SWITCH banner reason is a fixed category, not free text.
+- [ ] `--no-verify` never emitted in any `git commit` invocation.
+- [ ] Auto-commit uses `git add <specific-files>`, never `git add -A`.
+
+## AC Mapping
+
+| AC | How Addressed |
+|----|---------------|
+| AC-1 | G-06 auto-commit pass path requires build + lint PASS and code review PASS ("no blocking issues") before silent commit. |
+| AC-2 | G-06 auto-commit path delegates commit message format to existing 7g block — same convention as per-step. |
+| AC-3 | G-06 fail path names build, lint, review, and (per Q2) verification gate as revert triggers; MODE SWITCH banner is the notification. |
+| AC-4 | G-06 prose states mode flips to `per-step` for the remainder of the session; re-prompt only happens on a fresh `/dev-implement` invocation. |
+| Test "happy path" | Prose describes no-approval auto-commit for passing steps. |
+| Test "step 3 fails lint" | Prose describes mode switch on lint FAIL plus per-step for steps 4-N. |
+| Test "empty build_cmd" | Prose explicitly names empty check commands as non-blocking. |
+
+## Definition of Done
+
+- [ ] All issue ACs (AC-1…AC-4) satisfied by updated prose.
+- [ ] `grep "logic in #15"` → zero matches.
+- [ ] `grep "MODE SWITCH"` → exactly one match inside Step 7f.
+- [ ] `grep "no-verify"` → exactly one match inside Step 7g.
+- [ ] Internal consistency check in implementation Step 3 passes.
+- [ ] Plan + implementation doc committed under `docs/plans/issue-15/`.
+
+> Build / lint / test: N/A — `.paadhai.json` stack is `none`; docs-only change.
+
+## Brainstorming Decisions
+
+| Q | Decision | SRS Ref |
+|---|----------|---------|
+| Q1 | Empty check commands treated as non-blocking | FR-04 AC-3 |
+| Q2 | Verification gate FAIL also triggers revert | FR-06 + FR-04 AC-4, §6.3 |
+| Q3 | Failing step does not commit in auto-commit; falls through to per-step G-06 after fix | FR-04 AC-4 |
+| Q4 | Plain-text MODE SWITCH banner before per-step G-06 re-engages | FR-04 AC-4 |
+| Q5 | No cross-session persistence; re-prompt on resume | FR-04, Q-02 (open) |
+| Q6 | Code review stays binary PASS/FAIL; PASS = "no blocking issues" | FR-04 AC-3 |
+| Q7 | dev-parallel path out of scope; commit_mode applies only to sequential Step 7 | FR-04 |
+| Q8 | `--no-verify` forbidden; documented at 7g | §6.2 |
+
+## ADR
+
+Declined — no new technology, pattern, or breaking change.


### PR DESCRIPTION
## Summary

- Replace the `(logic in #15)` placeholder at G-06 (Step 7f of `dev-implement/SKILL.md`) with a 4-bullet block describing per-step, auto-commit pass path, auto-commit fail path, and batch modes.
- Add the MODE SWITCH banner literal inside Step 7f, shown when auto-commit reverts to per-step after any failure (build, lint, code review, or verification gate).
- Add a `--no-verify` safeguard paragraph at the end of Step 7g: auto-commit never bypasses pre-commit hooks; a hook failure triggers the same MODE SWITCH flow.
- Document auto-commit decisions (empty check commands treated as non-blocking; verification gate FAIL counts as a revert trigger; mode stays per-step for the remainder of the session once flipped).

## Changes

- `.claude/skills/dev-implement/SKILL.md` — expand G-06 at Step 7f, add no-verify safeguard at Step 7g.
- `docs/plans/issue-15/plan.md` — confirmed plan document.
- `docs/plans/issue-15/implementation.md` — step-by-step implementation doc with deviation log.

## Test Plan

`.paadhai.json` stack is `none` — no build/lint/test commands configured. Verification is by grep assertions against the updated `SKILL.md`:

- [x] `grep "logic in #15" SKILL.md` → 0 matches (placeholder removed)
- [x] `grep "MODE SWITCH: auto-commit → per-step" SKILL.md` → 1 match (banner literal, line 332)
- [x] `grep "no-verify" SKILL.md` → 1 match (safeguard, line 362)
- [x] `grep "logic in #16" SKILL.md` → 1 match (batch placeholder preserved for issue #16)
- [x] `grep "commit_mode" SKILL.md` → present in Step 2 (storage) + Step 7f G-06 + Step 7g safeguard; no orphans

## Acceptance Criteria

- [x] AC-1: Auto-commit mode skips G-06 for steps where build and lint pass and code review raises no blocking issues
- [x] AC-2: Auto-commit uses the standard commit message format (existing convention at Step 7g)
- [x] AC-3: Auto-commit mode reverts to per-step mode if any step fails build, lint, or review — and notifies the developer of the mode switch
- [x] AC-4: After reverting to per-step mode, all subsequent steps use per-step approval for the remainder of the session

## Notes

- Verification-gate FAIL (issue #12) is explicitly wired as a revert trigger alongside build/lint/review, preserving SRS §6.3 "no silent broken commits".
- `commit_mode` remains session-local (SRS Q-02 open; #14 decision inherited) — no persistence, re-prompt on resume.
- `dev-parallel` path is out of scope; `commit_mode` applies only to the sequential Step 7 loop.
- Implementation was dogfooded: this PR's own steps were executed in `auto-commit` mode. Deviations logged in `docs/plans/issue-15/implementation.md` — notably the plan's "MODE SWITCH count = 1" assertion was overly strict once Step 2 introduced a legitimate second prose reference in Step 7g; the banner literal line itself still appears exactly once.

Closes #15